### PR TITLE
fix(simplaylist): derive draw row range from dirtyRect instead of visibleRect

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistView.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistView.mm
@@ -824,10 +824,11 @@ NSPasteboardType const SimPlaylistPasteboardType = @"com.foobar2000.simplaylist.
 #pragma mark - Sparse Model Drawing
 
 - (void)drawSparseModelInRect:(NSRect)dirtyRect {
-    // Find visible row range (O(1) calculation)
-    NSRect visibleRect = [self visibleRect];
-    NSInteger firstRow = [self rowAtPoint:NSMakePoint(0, NSMinY(visibleRect))];
-    NSInteger lastRow = [self rowAtPoint:NSMakePoint(0, NSMaxY(visibleRect))];
+    // Derive row range from dirtyRect so we draw exactly what AppKit says needs
+    // drawing. AppKit issues a dirty rect only for the newly exposed strip on
+    // scroll — deriving from dirtyRect ensures those rows are always covered.
+    NSInteger firstRow = [self rowAtPoint:NSMakePoint(0, NSMinY(dirtyRect))];
+    NSInteger lastRow = [self rowAtPoint:NSMakePoint(0, NSMaxY(dirtyRect))];
 
     NSInteger totalRows = [self rowCount];
     if (firstRow < 0) firstRow = 0;
@@ -843,12 +844,10 @@ NSPasteboardType const SimPlaylistPasteboardType = @"com.foobar2000.simplaylist.
         [self fillGroupColumnBackgroundInRect:dirtyRect];
     }
 
-    // STEP 2: Draw only visible rows (typically ~30 rows)
+    // STEP 2: Draw rows in the dirty range
     for (NSInteger row = firstRow; row <= lastRow; row++) {
         NSRect rowRect = [self rectForRow:row];
-        if (NSIntersectsRect(rowRect, dirtyRect)) {
-            [self drawSparseRow:row inRect:rowRect];
-        }
+        [self drawSparseRow:row inRect:rowRect];
     }
 
     // STEP 3: Draw album art on top (after all row content)


### PR DESCRIPTION
Fixes #10

## Problem

Track text was missing when scrolling to albums outside the initial viewport. Clicking forced a redraw and the text appeared.
<img width="1574" height="870" alt="Screenshot 2026-02-28 at 12 43 27" src="https://github.com/user-attachments/assets/69d424c2-571b-4c47-b74b-4e07e7e71c7d" />

## Solution

`drawSparseModelInRect:` was deriving its row range from `[self visibleRect]` but filtering each row by `NSIntersectsRect(rowRect, dirtyRect)`. On scroll, AppKit only issues a `drawRect:` for the newly exposed strip — so rows inside `visibleRect` but outside that strip were skipped.

Derive the row range from `dirtyRect` directly so the draw loop covers exactly what AppKit says needs drawing, and remove the redundant per-row intersection check.