### PR TITLE
fix(simplaylist): space key toggles play/pause instead of selection

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistView.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistView.mm
@@ -2458,10 +2458,8 @@ NSPasteboardType const SimPlaylistPasteboardType = @"com.foobar2000.simplaylist.
             [self moveFocusBy:([self rowCount] - _focusIndex) extendSelection:hasShift];
             break;
 
-        case ' ':  // Space - toggle selection at focus
-            if (_focusIndex >= 0) {
-                [self toggleSelectionAtIndex:_focusIndex];
-            }
+        case ' ':  // Space - toggle play/pause (consistent with foobar2000 convention)
+            playback_control::get()->toggle_pause();
             break;
 
         case '\r':  // Enter - execute default action on focused track


### PR DESCRIPTION
Fixes #12

## Problem

Space was mapped to `toggleSelectionAtIndex:`, selecting/deselecting the focused track instead of toggling playback.

## Solution

Map space to `playback_control::get()->toggle_pause()`, consistent with foobar2000's standard keyboard convention and the documented behaviour.