### PR TITLE
fix(simplaylist): column widths auto-reset on layout resize

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
@@ -588,17 +588,21 @@ struct ReloadOperation {
 
     if (autoResizeCols.count == 0) return;
 
-    // Distribute remaining space
+    // Distribute remaining space proportionally to preserve user-adjusted column ratios
     CGFloat remainingWidth = availableWidth - fixedWidth;
-    if (remainingWidth < 0) return;
+    if (remainingWidth <= 0) return;
 
-    CGFloat widthPerCol = remainingWidth / autoResizeCols.count;
-    widthPerCol = MAX(widthPerCol, 50);  // Minimum 50px
+    CGFloat totalAutoWidth = 0;
+    for (ColumnDefinition *col in autoResizeCols) {
+        totalAutoWidth += col.width;
+    }
 
     BOOL changed = NO;
     for (ColumnDefinition *col in autoResizeCols) {
-        if (fabs(col.width - widthPerCol) > 1.0) {
-            col.width = widthPerCol;
+        CGFloat proportion = (totalAutoWidth > 0) ? col.width / totalAutoWidth : 1.0 / (CGFloat)autoResizeCols.count;
+        CGFloat newWidth = remainingWidth * proportion;
+        if (fabs(col.width - newWidth) > 1.0) {
+            col.width = newWidth;
             changed = YES;
         }
     }
@@ -2435,9 +2439,10 @@ static NSString *const kQueuePositionSentinel = @"__queue_position__";
 - (void)headerBar:(SimPlaylistHeaderBar *)bar didResizeColumn:(NSInteger)columnIndex toWidth:(CGFloat)newWidth {
     if (columnIndex < 0 || columnIndex >= (NSInteger)_columns.count) return;
 
-    // Update column definition
+    // Update column definition; disable auto-resize so this width is preserved on view resize
     ColumnDefinition *col = _columns[columnIndex];
     col.width = newWidth;
+    col.autoResize = NO;
 
     // Update playlist view
     [_playlistView reloadData];


### PR DESCRIPTION
This PR fixes column widths resetting on layout resize. 


## Problem
If user changes width of i.e. Title/Artist columns in SimPlaylist and after that changes size of another UI element (`albumart` for example), SimPlayst performed a reset of columns to default width.
Screenshot of the bug:
<img width="1820" height="1050" alt="Screenshot 2026-04-20 at 19 05 34" src="https://github.com/user-attachments/assets/aed1a3df-039c-4aec-a9b6-8d1466d8e4f2" />

## Solution

- When the user manually resized a column, it remained marked as `autoResize=YES`, so any subsequent view resize (e.g. dragging an adjacent layout panel) would recalculate and overwrite the user-set width. 
  - Fixed by setting `autoResize=NO` on manual column resize.                                                                                                                                                                                                                                                     

- Also fix `autoResizeColumns` distributing space equally (resetting all auto-resize columns to the same width) and a 50px-per-column minimum that could make total column width exceed available space, causing a horizontal scrollbar. 
  - Now distributes remaining space proportionally to preserve relative column sizing. 