### PR TITLE
fix(scrobble): percent-encode &=+# symbols in URL params

### DIFF
--- a/extensions/foo_jl_scrobble_mac/src/LastFm/LastFmClient.mm
+++ b/extensions/foo_jl_scrobble_mac/src/LastFm/LastFmClient.mm
@@ -71,8 +71,9 @@
 #pragma mark - URL Building
 
 - (NSString*)urlEncode:(NSString*)string {
-    return [string stringByAddingPercentEncodingWithAllowedCharacters:
-            [NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSMutableCharacterSet *allowed = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [allowed removeCharactersInString:@"&=+#"];
+    return [string stringByAddingPercentEncodingWithAllowedCharacters:allowed];
 }
 
 - (NSString*)buildPostBody:(NSDictionary<NSString*, NSString*>*)params {


### PR DESCRIPTION
This PR fixes encoding of certain symbols when calling Last.fm API. 
  
## Problem

`URLQueryAllowedCharacterSet` does not percent-encode `&, =, +, #` because they are syntactically valid in a URL query string. However, when these characters appear inside a parameter value in a `application/x-www-form-urlencoded` POST body, they are misinterpreted as structural delimiter `&` splits parameters, `=` splits key/value, `+` decodes as a space, `#` starts a fragment. 
As a result, scrobbles for artists or tracks whose names contain any of these characters (e.g. `Simon & Garfunkel`) were silently sent to Last.fm with corrupted metadata and thus not accepted for scrobbling.


## Solution

Create a mutable copy of `URLQueryAllowedCharacterSet` and remove `&, =, +, #` before encoding each parameter value. This ensures those characters are percent-encoded as `%26, %3D, %2B, %23` and cannot be mistaken for POST body structure by the Last.fm API parser.