### PR TITLE
fix(simplaylist): use file-specific extractor to prevent cover art bleed-through

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
@@ -220,37 +220,35 @@ static NSImage *_placeholderImage = nil;
             FB2K_console_formatter() << "[SimPlaylist] Album art file load error: " << exception.reason.UTF8String;
         }
 
-        // Second try: use SDK (may not work well on background thread)
+        // Second try: use album_art_extractor_manager which extracts art directly
+        // from the file without fallback resolution (unlike album_art_manager_v2
+        // which can return art from unrelated tracks via its stub/fallback system).
         if (!image) {
             @try {
-                auto art_mgr = album_art_manager_v2::tryGet();
-                if (art_mgr.is_valid() && handleCopy.is_valid()) {
-                    try {
-                        metadb_handle_list items;
-                        items.add_item(handleCopy);
-
-                        pfc::list_t<GUID> ids;
-                        ids.add_item(album_art_ids::cover_front);
-
-                        album_art_extractor_instance_v2::ptr extractor = art_mgr->open(items, ids, fb2k::noAbort);
-
-                        if (extractor.is_valid()) {
-                            album_art_data::ptr data;
-                            if (extractor->query(album_art_ids::cover_front, data, fb2k::noAbort)) {
-                                if (data.is_valid() && data->size() > 0) {
-                                    NSData *imageData = [NSData dataWithBytes:data->data()
-                                                                       length:data->size()];
-                                    if (imageData) {
-                                        image = [[NSImage alloc] initWithData:imageData];
-                                        if (image && (image.size.width > 512 || image.size.height > 512)) {
-                                            image = [self resizeImage:image toMaxSize:512];
+                if (handleCopy.is_valid()) {
+                    const char *path = handleCopy->get_path();
+                    if (path) {
+                        try {
+                            album_art_extractor_instance_ptr extractor =
+                                album_art_extractor::g_open(nullptr, path, fb2k::noAbort);
+                            if (extractor.is_valid()) {
+                                album_art_data::ptr data;
+                                if (extractor->query(album_art_ids::cover_front, data, fb2k::noAbort)) {
+                                    if (data.is_valid() && data->size() > 0) {
+                                        NSData *imageData = [NSData dataWithBytes:data->data()
+                                                                           length:data->size()];
+                                        if (imageData) {
+                                            image = [[NSImage alloc] initWithData:imageData];
+                                            if (image && (image.size.width > 512 || image.size.height > 512)) {
+                                                image = [self resizeImage:image toMaxSize:512];
+                                            }
                                         }
                                     }
                                 }
                             }
+                        } catch (...) {
+                            // No embedded art or unsupported format — not an error
                         }
-                    } catch (...) {
-                        // SDK album art extraction failed (no embedded art or format error)
                     }
                 }
             } @catch (NSException *exception) {


### PR DESCRIPTION
This PR fixes album art bleeding through from other tracks in SimPlaylist when a track has no cover art.

In case there's media files from `Downloads` folder in your playlist and the same folder also contains a file like `cover.jpg`, this image will get populated to a lot of albums across all playlists that cannot find cover art in their parent folder.

## Problem
   
`album_art_manager_v2` is foobar2000's viewer-level art manager and performs fallback resolution — when a track has no art of its own, it searches broader context and can return art associated with another track from the same session or folder. This caused tracks without cover art to incorrectly display album art from an unrelated track (e.g. Bloodborne OST appearing for tracks that have no cover).

<img width="1700" height="980" alt="Screenshot 2026-05-11 at 13 17 57" src="https://github.com/user-attachments/assets/c9a8eabd-993d-46d2-bf32-29af467a5716" />


## Solution

Replace `album_art_manager_v2` with `album_art_extractor::g_open()`, a static helper that opens and extracts art directly from a specific file without any fallback resolution. Tracks with no embedded art or matching cover image file now correctly show the placeholder instead of bleeding art from unrelated tracks.