### PR TITLE
feature(simplaylist): add grouping pattern for multi-artists releases like compilations, etc.

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/Tests/GroupBuilderTests.mm
+++ b/extensions/foo_jl_simplaylist_mac/Tests/GroupBuilderTests.mm
@@ -17,12 +17,16 @@
 // Test track data: parallel header/subgroup arrays. artKey is "art<i>".
 struct FakeTracks {
     std::vector<std::string> headers;
+    std::vector<std::string> groupKeys;  // may be empty when unused
     std::vector<std::string> subgroups;  // may be empty when unused
     mutable std::string artBuf;
 
     simplaylist::GroupBuildCallbacks callbacks(std::function<bool()> cancelled = nullptr) const {
         simplaylist::GroupBuildCallbacks cb;
         cb.formatHeader = [this](size_t i) { return headers[i].c_str(); };
+        if (!groupKeys.empty()) {
+            cb.formatGroupKey = [this](size_t i) { return groupKeys[i].c_str(); };
+        }
         if (!subgroups.empty()) {
             cb.formatSubgroup = [this](size_t i) { return subgroups[i].c_str(); };
         }
@@ -124,6 +128,32 @@ int main(void) {
             checkArray(chunked.subgroupStarts, full.subgroupStarts, what);
             checkArray(chunked.subgroupHeaders, full.subgroupHeaders, what);
         }
+    }
+
+    // --- Grouping key: boundaries on the key, headers stay per-group display text ---
+    {
+        g_context = "group-key";
+        FakeTracks t;
+        // Multi-artist album: headers differ per track, key keeps them together
+        t.headers = {"Artist1 - Album1", "Artist2 - Album1", "Artist3 - Album2", "Artist3 - Album2"};
+        t.groupKeys = {"Album1", "Album1", "Album2", "Album2"};
+        BuildResult r;
+        std::string cur;
+        SubgroupDetector det(true);
+        simplaylist::buildGroups(0, t.headers.size(), false, true, cur, det, t.callbacks(),
+                                 r.groupStarts, r.groupHeaders, r.groupArtKeys,
+                                 r.subgroupStarts, r.subgroupHeaders);
+        checkArray(r.groupStarts, @[@0, @2], "groups break on key changes only");
+        checkArray(r.groupHeaders, @[@"Artist1 - Album1", @"Artist3 - Album2"],
+                   "header text taken from first track of each group");
+        CHECK(cur == "Album2", "carried state holds the key, not the header");
+
+        // Continuation seeded with the key: same key at the seam -> no boundary
+        BuildResult r2;
+        simplaylist::buildGroups(2, t.headers.size(), false, false, cur, det, t.callbacks(),
+                                 r2.groupStarts, r2.groupHeaders, r2.groupArtKeys,
+                                 r2.subgroupStarts, r2.subgroupHeaders);
+        checkArray(r2.groupStarts, @[], "no boundary at seam with matching key");
     }
 
     // --- Subgroup wiring: isNewGroup reaches the detector ---

--- a/extensions/foo_jl_simplaylist_mac/src/Core/ConfigHelper.h
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/ConfigHelper.h
@@ -205,6 +205,7 @@ inline const char* getDefaultGroupPresetsJSON() {
         "pattern": "[$if2(%album artist%,%artist%) - ]['['%date%']' ][%album%]",
         "display": "text"
       },
+      "grouping_pattern": "['['%date%']' ][%album%]",
       "group_column": {
         "pattern": "[%album%]",
         "display": "front"

--- a/extensions/foo_jl_simplaylist_mac/src/Core/GroupBuilder.h
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/GroupBuilder.h
@@ -24,6 +24,11 @@ struct GroupBuildCallbacks {
     // Returned pointers only need to stay valid until the next callback
     // invocation (callers typically return .c_str() of one reused buffer).
     std::function<const char *(size_t index)> formatHeader;
+    // Optional boundary-detection key. When set, group breaks are detected on
+    // this key instead of the header text (a multi-artist album keeps one
+    // group even though per-track headers differ) and formatHeader is only
+    // invoked for the first track of each group.
+    std::function<const char *(size_t index)> formatGroupKey;
     std::function<const char *(size_t index)> formatSubgroup;  // required iff hasSubgroups
     std::function<const char *(size_t index)> artKey;
     // Optional cooperative cancellation, checked once per track before any
@@ -33,16 +38,17 @@ struct GroupBuildCallbacks {
 };
 
 // Appends groups/subgroups detected for tracks [begin, end) to the output
-// arrays. `currentHeader` and `detector` carry state across chunked
+// arrays. `currentKey` and `detector` carry state across chunked
 // invocations (the background continuation passes the sync scan's final
-// values). `forceFirstNewGroup` reproduces the "index 0 always starts a
-// group" rule of from-scratch scans — even when its header equals the seeded
-// currentHeader — and must be false for continuations.
+// values); it holds the last group's boundary key — the header text unless
+// formatGroupKey is set. `forceFirstNewGroup` reproduces the "index 0 always
+// starts a group" rule of from-scratch scans — even when its key equals the
+// seeded currentKey — and must be false for continuations.
 // Returns false if cancelled.
 inline bool buildGroups(size_t begin, size_t end,
                         bool hasSubgroups,
                         bool forceFirstNewGroup,
-                        std::string &currentHeader,
+                        std::string &currentKey,
                         SubgroupDetector &detector,
                         const GroupBuildCallbacks &cb,
                         NSMutableArray<NSNumber *> *groupStarts,
@@ -53,10 +59,12 @@ inline bool buildGroups(size_t begin, size_t end,
     for (size_t i = begin; i < end; i++) { @autoreleasepool {
         if (cb.isCancelled && cb.isCancelled()) return false;
 
-        const char *header = cb.formatHeader(i);
-        bool isNewGroup = (forceFirstNewGroup && i == begin) || (currentHeader != header);
+        const char *key = cb.formatGroupKey ? cb.formatGroupKey(i) : cb.formatHeader(i);
+        bool isNewGroup = (forceFirstNewGroup && i == begin) || (currentKey != key);
 
         if (isNewGroup) {
+            currentKey = key;  // copy before formatHeader may reuse the key's buffer
+            const char *header = cb.formatGroupKey ? cb.formatHeader(i) : currentKey.c_str();
             // stringWithUTF8String: returns nil on invalid UTF-8 in tags;
             // addObject:nil would throw on a background thread. A NULL is worse
             // still - stringWithUTF8String:NULL is undefined, and the SDK's
@@ -65,7 +73,6 @@ inline bool buildGroups(size_t begin, size_t end,
             [groupStarts addObject:@(i)];
             [groupHeaders addObject:([NSString stringWithUTF8String:header] ?: @"")];
             [groupArtKeys addObject:(art ? ([NSString stringWithUTF8String:art] ?: @"") : @"")];
-            currentHeader = header;
             detector.enterNewGroup();
         }
 

--- a/extensions/foo_jl_simplaylist_mac/src/Core/GroupPreset.h
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/GroupPreset.h
@@ -40,6 +40,12 @@ typedef NS_ENUM(NSInteger, GroupDisplayType) {
 @property (nonatomic, copy) NSString *headerPattern;
 @property (nonatomic, assign) GroupDisplayType headerDisplayType;
 
+// Grouping key pattern — if non-empty, used for group boundary detection instead of headerPattern.
+// Allows the display header to differ from the key used to compare consecutive tracks.
+// Example: headerPattern shows "Artist – Album" but groupingPattern keys on "Album" only,
+// so a multi-artist album is kept as a single group.
+@property (nonatomic, copy) NSString *groupingPattern;
+
 // Group column (album art area) configuration
 @property (nonatomic, copy) NSString *groupColumnPattern;
 @property (nonatomic, assign) GroupDisplayType groupColumnDisplayType;

--- a/extensions/foo_jl_simplaylist_mac/src/Core/GroupPreset.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/GroupPreset.mm
@@ -25,6 +25,7 @@
     preset.sortingPattern = @"%path_sort%";
     preset.headerPattern = @"";
     preset.headerDisplayType = GroupDisplayTypeText;
+    preset.groupingPattern = @"";
     preset.groupColumnPattern = @"";
     preset.groupColumnDisplayType = GroupDisplayTypeFront;
     preset.subgroups = @[];
@@ -76,6 +77,7 @@
     GroupPreset *basic = [GroupPreset presetWithName:@"Album"];
     basic.sortingPattern = @"%path_sort%";
     basic.headerPattern = @"[$if2(%album artist%,%artist%) - ]['['%date%']' ][%album%]";
+    basic.groupingPattern = @"['['%date%']' ][%album%]";
     basic.groupColumnPattern = @"[%album%]";
     basic.groupColumnDisplayType = GroupDisplayTypeFront;
     basic.subgroups = @[
@@ -149,6 +151,10 @@
             if ([display isKindOfClass:[NSString class]]) preset.headerDisplayType = [self displayTypeFromString:display];
         }
 
+        // Grouping key pattern (optional — falls back to headerPattern when absent)
+        NSString *groupingPattern = presetDict[@"grouping_pattern"];
+        if (groupingPattern) preset.groupingPattern = groupingPattern;
+
         // Group column
         NSDictionary *groupColDict = presetDict[@"group_column"];
         if ([groupColDict isKindOfClass:[NSDictionary class]]) {
@@ -196,6 +202,11 @@
             @"pattern": preset.headerPattern ?: @"",
             @"display": [self stringFromDisplayType:preset.headerDisplayType]
         };
+
+        // Grouping key pattern (omit when empty to keep JSON compact)
+        if (preset.groupingPattern.length > 0) {
+            presetDict[@"grouping_pattern"] = preset.groupingPattern;
+        }
 
         // Group column
         presetDict[@"group_column"] = @{

--- a/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
@@ -1189,6 +1189,13 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
     titleformat_object::ptr headerScript =
         simplaylist::TitleFormatHelper::compileWithFallback([preset.headerPattern UTF8String], nullptr);
 
+    // Compile grouping key pattern (boundary detection, optional)
+    titleformat_object::ptr groupingScript;
+    BOOL hasGroupingPattern = (preset.groupingPattern.length > 0);
+    if (hasGroupingPattern) {
+        groupingScript = simplaylist::TitleFormatHelper::compileWithFallback([preset.groupingPattern UTF8String], nullptr);
+    }
+
     // Compile subgroup pattern (if any)
     NSString *subgroupPattern = [preset subgroupPattern];
     titleformat_object::ptr subgroupScript;
@@ -1214,8 +1221,9 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
     // Use shared SubgroupDetector to ensure consistent logic across all code paths
     SubgroupDetector subgroupDetector(showFirstSubgroup, g_subgroupDebugEnabled);
 
-    std::string currentHeader;
+    std::string currentGroupKey;
     pfc::string8 formattedHeader;
+    pfc::string8 formattedGroupingKey;
     pfc::string8 formattedSubgroup;
 
     simplaylist::GroupBuildCallbacks buildCb;
@@ -1223,6 +1231,12 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
         handles[i]->format_title(nullptr, formattedHeader, headerScript, nullptr);
         return formattedHeader.c_str();
     };
+    if (hasGroupingPattern) {
+        buildCb.formatGroupKey = [&](size_t i) {
+            handles[i]->format_title(nullptr, formattedGroupingKey, groupingScript, nullptr);
+            return formattedGroupingKey.c_str();
+        };
+    }
     if (hasSubgroups) {
         buildCb.formatSubgroup = [&](size_t i) {
             handles[i]->format_title(nullptr, formattedSubgroup, subgroupScript, nullptr);
@@ -1233,7 +1247,7 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
 
     simplaylist::buildGroups(0, MIN((size_t)detectUpTo, (size_t)handles.get_count()),
                              hasSubgroups, /* forceFirstNewGroup */ true,
-                             currentHeader, subgroupDetector, buildCb,
+                             currentGroupKey, subgroupDetector, buildCb,
                              groupStarts, groupHeaders, groupArtKeys,
                              subgroupStarts, subgroupHeaders);
 
@@ -1261,7 +1275,10 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
     if (detectUpTo < itemCount) {
         auto handlesPtr = std::make_shared<metadb_handle_list>(std::move(handles));
         NSString *headerPattern = preset.headerPattern;
-        NSString *lastHeader = (groupHeaders.count > 0) ? [groupHeaders lastObject] : @"";
+        NSString *groupingPattern = preset.groupingPattern;
+        // Seed the seam comparison with the sync scan's final boundary key
+        // (equals the last header text unless a grouping pattern is active)
+        NSString *lastGroupKey = [NSString stringWithUTF8String:currentGroupKey.c_str()];
         // IMPORTANT: Use the actual subgroup state from detector, not subgroupHeaders.lastObject
         // because if showFirstSubgroup=OFF, the first subgroup wasn't added to the list.
         // Kept as std::string: the NSString round-trip yielded nil for invalid
@@ -1279,12 +1296,18 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
             NSMutableArray<NSNumber *> *moreSubgroupStarts = [NSMutableArray array];
             NSMutableArray<NSString *> *moreSubgroupHeaders = [NSMutableArray array];
 
-            std::string bgCurrentHeader([lastHeader UTF8String]);
+            std::string bgCurrentGroupKey([lastGroupKey UTF8String]);
             pfc::string8 bgFormattedHeader;
+            pfc::string8 bgFormattedGroupingKey;
             pfc::string8 bgFormattedSubgroup;
 
             titleformat_object::ptr bgHeaderScript =
                 simplaylist::TitleFormatHelper::compileWithFallback([headerPattern UTF8String], nullptr);
+
+            titleformat_object::ptr bgGroupingScript;
+            if (hasGroupingPattern) {
+                bgGroupingScript = simplaylist::TitleFormatHelper::compileWithFallback([groupingPattern UTF8String], nullptr);
+            }
 
             titleformat_object::ptr bgSubgroupScript;
             if (hasSubgroups) {
@@ -1307,6 +1330,12 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
                 (*handlesPtr)[i]->format_title(nullptr, bgFormattedHeader, bgHeaderScript, nullptr);
                 return bgFormattedHeader.c_str();
             };
+            if (hasGroupingPattern) {
+                buildCb.formatGroupKey = [&](size_t i) {
+                    (*handlesPtr)[i]->format_title(nullptr, bgFormattedGroupingKey, bgGroupingScript, nullptr);
+                    return bgFormattedGroupingKey.c_str();
+                };
+            }
             if (hasSubgroups) {
                 buildCb.formatSubgroup = [&](size_t i) {
                     (*handlesPtr)[i]->format_title(nullptr, bgFormattedSubgroup, bgSubgroupScript, nullptr);
@@ -1318,7 +1347,7 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
 
             if (!simplaylist::buildGroups(detectUpTo, handlesPtr->get_count(),
                                           hasSubgroups, /* forceFirstNewGroup */ false,
-                                          bgCurrentHeader, bgSubgroupDetector, buildCb,
+                                          bgCurrentGroupKey, bgSubgroupDetector, buildCb,
                                           moreGroupStarts, moreGroupHeaders, moreGroupArtKeys,
                                           moreSubgroupStarts, moreSubgroupHeaders)) {
                 return;
@@ -1407,6 +1436,7 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
     // Copy handles to a shared_ptr for thread safety
     auto handlesPtr = std::make_shared<metadb_handle_list>(std::move(handles));
     NSString *headerPattern = preset.headerPattern;
+    NSString *groupingPattern = preset.groupingPattern;
     NSString *subgroupPattern = [preset subgroupPattern];  // Get first subgroup pattern
 
     // PROGRESSIVE: Detect groups in background without blocking UI
@@ -1417,6 +1447,15 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
         // Compile header pattern
         titleformat_object::ptr headerScript =
             simplaylist::TitleFormatHelper::compileWithFallback([headerPattern UTF8String], nullptr);
+
+        // Compile grouping key pattern (boundary detection).
+        // When set, consecutive tracks with the same grouping key are kept in one group
+        // even if their header text differs (e.g., multi-artist albums).
+        titleformat_object::ptr groupingScript;
+        BOOL hasGroupingPattern = (groupingPattern && groupingPattern.length > 0);
+        if (hasGroupingPattern) {
+            groupingScript = simplaylist::TitleFormatHelper::compileWithFallback([groupingPattern UTF8String], nullptr);
+        }
 
         // Compile subgroup pattern (if any)
         titleformat_object::ptr subgroupScript;
@@ -1443,8 +1482,9 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
         SubgroupDetector subgroupDetector(showFirstSubgroup, g_subgroupDebugEnabled);
 
         // format_title with metadb_handle is thread-safe for reading
-        std::string currentHeader;
+        std::string currentGroupKey;
         pfc::string8 formattedHeader;
+        pfc::string8 formattedGroupingKey;
         pfc::string8 formattedSubgroup;
 
         simplaylist::GroupBuildCallbacks buildCb;
@@ -1452,6 +1492,12 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
             (*handlesPtr)[i]->format_title(nullptr, formattedHeader, headerScript, nullptr);
             return formattedHeader.c_str();
         };
+        if (hasGroupingPattern) {
+            buildCb.formatGroupKey = [&](size_t i) {
+                (*handlesPtr)[i]->format_title(nullptr, formattedGroupingKey, groupingScript, nullptr);
+                return formattedGroupingKey.c_str();
+            };
+        }
         if (hasSubgroups) {
             buildCb.formatSubgroup = [&](size_t i) {
                 (*handlesPtr)[i]->format_title(nullptr, formattedSubgroup, subgroupScript, nullptr);
@@ -1463,7 +1509,7 @@ static NSInteger calculatePaddingForGroup(NSInteger trackCount, NSInteger subgro
 
         if (!simplaylist::buildGroups(0, handlesPtr->get_count(),
                                       hasSubgroups, /* forceFirstNewGroup */ true,
-                                      currentHeader, subgroupDetector, buildCb,
+                                      currentGroupKey, subgroupDetector, buildCb,
                                       groupStarts, groupHeaders, groupArtKeys,
                                       subgroupStarts, subgroupHeaders)) {
             return;
@@ -1798,6 +1844,7 @@ static BOOL validCachedStringArray(NSArray *arr) {
 
     auto handlesPtr = std::make_shared<metadb_handle_list>(std::move(handles));
     NSString *headerPattern = preset.headerPattern;
+    NSString *groupingPattern = preset.groupingPattern;
     NSString *subgroupPattern = [preset subgroupPattern];
 
     __weak typeof(self) weakSelf = self;
@@ -1807,6 +1854,12 @@ static BOOL validCachedStringArray(NSArray *arr) {
         // Compile patterns
         titleformat_object::ptr headerScript =
             simplaylist::TitleFormatHelper::compileWithFallback([headerPattern UTF8String], nullptr);
+
+        titleformat_object::ptr groupingScript;
+        BOOL hasGroupingPattern = (groupingPattern && groupingPattern.length > 0);
+        if (hasGroupingPattern) {
+            groupingScript = simplaylist::TitleFormatHelper::compileWithFallback([groupingPattern UTF8String], nullptr);
+        }
 
         titleformat_object::ptr subgroupScript;
         BOOL hasSubgroups = (subgroupPattern && subgroupPattern.length > 0);
@@ -1827,8 +1880,9 @@ static BOOL validCachedStringArray(NSArray *arr) {
             simplaylist_config::kDefaultShowFirstSubgroupHeader);
         SubgroupDetector subgroupDetector(showFirstSubgroup, g_subgroupDebugEnabled);
 
-        std::string currentHeader;
+        std::string currentGroupKey;
         pfc::string8 formattedHeader;
+        pfc::string8 formattedGroupingKey;
         pfc::string8 formattedSubgroup;
 
         simplaylist::GroupBuildCallbacks buildCb;
@@ -1836,6 +1890,12 @@ static BOOL validCachedStringArray(NSArray *arr) {
             (*handlesPtr)[i]->format_title(nullptr, formattedHeader, headerScript, nullptr);
             return formattedHeader.c_str();
         };
+        if (hasGroupingPattern) {
+            buildCb.formatGroupKey = [&](size_t i) {
+                (*handlesPtr)[i]->format_title(nullptr, formattedGroupingKey, groupingScript, nullptr);
+                return formattedGroupingKey.c_str();
+            };
+        }
         if (hasSubgroups) {
             buildCb.formatSubgroup = [&](size_t i) {
                 (*handlesPtr)[i]->format_title(nullptr, formattedSubgroup, subgroupScript, nullptr);
@@ -1847,7 +1907,7 @@ static BOOL validCachedStringArray(NSArray *arr) {
 
         if (!simplaylist::buildGroups(0, handlesPtr->get_count(),
                                       hasSubgroups, /* forceFirstNewGroup */ true,
-                                      currentHeader, subgroupDetector, buildCb,
+                                      currentGroupKey, subgroupDetector, buildCb,
                                       groupStarts, groupHeaders, groupArtKeys,
                                       subgroupStarts, subgroupHeaders)) {
             return;


### PR DESCRIPTION
If a release (album, compilation), has multiple artists, it should show in `SimPlaylist` as one album instead of album for each of the contributing artists.

## Problem:
The `Artist – album / cover` preset groups tracks by evaluating `[%album artist% - ]['['%date%']' ][%album%]` and comparing the resulting string between consecutive tracks. For multi-artist releases where `%album artist%` differs per track (e.g., each track is tagged with its contributing artist rather than `Various Artists`), the comparison produces a different string for each artist, splitting what is a single album into one group per artist.                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                          
## Solution:
Add a `groupingPattern` field to `GroupPreset`, separate from `headerPattern`. 
When set, it is compiled and evaluated independently and its output is used as the group boundary key instead of the header text — the header text is still produced by `headerPattern` and displayed as-is. The default `Artist – album / cover` preset now sets `groupingPattern` to `['['%date%']' ][%album%]`, keying only on album title and year. Tracks on the same album are therefore kept in one group regardless of how `%album artist%` is tagged per track. When `groupingPattern` is absent (all existing user-saved presets), the behaviour is identical to before, making this fully backwards compatible. 