### PR TITLE
 fix(simplaylist): cover art for external volumes and smarter companion-file matching

### DIFF
--- a/docs/VOLUME_UUID_ISSUE.md
+++ b/docs/VOLUME_UUID_ISSUE.md
@@ -30,6 +30,40 @@ Instead of relying solely on macOS-assigned UUIDs for network mounts, foobar cou
 
 This affects playlist management globally - any component storing `mac-volume://` URLs faces this issue. The Playlist Organizer (plorg) would be the appropriate place for such a cleanup tool since it already handles cross-playlist operations.
 
+## Impact on SimPlaylist Cover Art (Fixed 2026-05-24)
+
+`mac-volume://UUID/path` URIs also affect SimPlaylist's file-based cover art lookup.
+`AlbumArtCache` used a two-stage approach: (1) direct `NSFileManager` file lookup,
+(2) `album_art_extractor::g_open` for embedded art. Both failed for external volumes:
+
+- **Stage 1** — `NSFileManager` only handles POSIX paths. `mac-volume://` paths are
+  passed verbatim, `fileExistsAtPath:` returns NO, and no external art file is found.
+- **Stage 2** — `album_art_extractor` only reads art **embedded in the audio file**
+  itself. Albums that store art exclusively as a companion file (`cover.jpg`, etc.)
+  return nothing.
+
+**Why the albumart component worked**: it uses `album_art_manager_v2`, a higher-level
+fb2k SDK API that handles all fb2k path schemes natively (including `mac-volume://`)
+and searches both embedded and companion/external art files.
+
+**UUID resolution is not feasible**: fb2k's UUID in `mac-volume://UUID` does **not**
+match any macOS-exposed volume identifier — not `NSURLVolumeUUIDStringKey`, not
+`diskutil`'s Volume UUID, not the IOKit MediaUUID. The UUID source is fb2k-internal.
+Any scheme that tries to enumerate mounted volumes and match by UUID will silently fail.
+
+**The fix (`AlbumArtCache.mm`, 2026-05-24):**
+
+Stage 2 is replaced with `album_art_manager_v2::open()`, the same API the albumart
+component uses. A bleed-through guard is applied via `query_paths()`: the manager
+can return library-wide stub art for tracks that have no art at all; we prevent this
+by only accepting the result when the art source path lives in the same directory
+as the track. Embedded art (no external source path) is always accepted.
+
+Additionally, the `noImageKeys` session blacklist now purges entries for newly-mounted
+volumes on `NSWorkspaceDidMountNotification`, matching both POSIX (`/Volumes/…`) and
+`mac-volume://UUID/…` key formats, so art that failed to load before a drive finished
+mounting is automatically retried.
+
 ## Workaround (Manual)
 
 For immediate fixes, orphaned UUIDs can be replaced via sed in playlist `.fplite` files (which are CSV format):

--- a/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
@@ -196,10 +196,51 @@ static NSImage *_placeholderImage = nil;
                     NSFileManager *fm = [NSFileManager defaultManager];
 
                     if (directory.length > 0 && [fm fileExistsAtPath:directory]) {
-                        // Common cover image filenames
-                        NSArray *coverNames = @[@"cover.jpg", @"cover.png", @"folder.jpg", @"folder.png",
-                                               @"front.jpg", @"front.png", @"album.jpg", @"album.png",
-                                               @"Cover.jpg", @"Cover.png", @"Folder.jpg", @"Folder.png"];
+                        // Build candidate names:
+                        // - metadata-driven files (%album%.* and %artist% - %album%.* patterns)
+                        // - conventional fallbacks
+                        // Using metadata-derived names is *safer* than a hardcoded list since a file named after the
+                        // album is far less likely to be a false match in a flat directory full of unrelated files.
+                        NSMutableArray<NSString *> *coverNames = [NSMutableArray array];
+
+                        // 1. Metadata-derived candidates
+                        pfc::string8 albumStr, artistStr;
+                        try {
+                            metadb_info_container::ptr infoContainer;
+                            if (handleCopy->get_info_ref(infoContainer) && infoContainer.is_valid()) {
+                                const file_info &fi = infoContainer->info();
+                                const char *album = fi.meta_get("ALBUM", 0);
+                                if (album) albumStr = album;
+                                const char *artist = fi.meta_get("ARTIST", 0);
+                                if (artist) artistStr = artist;
+                            }
+                        } catch (...) {}
+
+                        if (albumStr.length() > 0) {
+                            NSString *album = [NSString stringWithUTF8String:albumStr.get_ptr()];
+                            for (NSString *ext in @[@"jpg", @"png", @"jpeg"]) {
+                                // %album%.ext  e.g. "().jpg", "Revolver.jpg"
+                                [coverNames addObject:[album stringByAppendingPathExtension:ext]];
+                            }
+                            if (artistStr.length() > 0) {
+                                NSString *artist = [NSString stringWithUTF8String:artistStr.get_ptr()];
+                                for (NSString *ext in @[@"jpg", @"png", @"jpeg"]) {
+                                    // %artist% - %album%.ext  e.g. "Sigur Ros - ().jpg"
+                                    NSString *name = [NSString stringWithFormat:@"%@ - %@", artist, album];
+                                    [coverNames addObject:[name stringByAppendingPathExtension:ext]];
+                                }
+                            }
+                        }
+
+                        // 2. Conventional fallback names
+                        [coverNames addObjectsFromArray:@[
+                            @"cover.jpg",  @"cover.png",
+                            @"folder.jpg", @"folder.png",
+                            @"front.jpg",  @"front.png",
+                            @"album.jpg",  @"album.png",
+                            @"Cover.jpg",  @"Cover.png",
+                            @"Folder.jpg", @"Folder.png"
+                        ]];
 
                         for (NSString *name in coverNames) {
                             NSString *coverPath = [directory stringByAppendingPathComponent:name];

--- a/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
@@ -52,6 +52,15 @@ static NSImage *_placeholderImage = nil;
         _pendingLoads = [NSMutableSet set];
         _pendingCompletions = [NSMutableDictionary dictionary];
         _pendingLock = [[NSLock alloc] init];
+
+        // When a volume mounts, purge any noImageKeys that live under it so that
+        // cover art that was missed because the drive wasn't ready (e.g. at startup)
+        // is retried on the next draw cycle.
+        [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver:self
+               selector:@selector(volumeDidMount:)
+                   name:NSWorkspaceDidMountNotification
+                 object:nil];
     }
     return self;
 }
@@ -186,7 +195,13 @@ static NSImage *_placeholderImage = nil;
                 const char *path = handleCopy->get_path();
                 if (path) {
                     NSString *filePath = [NSString stringWithUTF8String:path];
-                    // Remove file:// prefix if present
+                    // Normalise to a POSIX path that NSFileManager understands.
+                    // foobar2000 uses file:// for paths on the startup volume and
+                    // mac-volume://UUID/... for external volumes. The mac-volume://
+                    // UUID is fb2k-internal and does not match any macOS volume UUID
+                    // (NSURLVolumeUUIDStringKey, diskutil, IOKit etc.), so we cannot
+                    // resolve it here. mac-volume:// paths are handled by the
+                    // album_art_manager_v2 fallback below.
                     if ([filePath hasPrefix:@"file://"]) {
                         filePath = [filePath substringFromIndex:7];
                         filePath = [filePath stringByRemovingPercentEncoding];
@@ -261,34 +276,76 @@ static NSImage *_placeholderImage = nil;
             FB2K_console_formatter() << "[SimPlaylist] Album art file load error: " << exception.reason.UTF8String;
         }
 
-        // Second try: use album_art_extractor_manager which extracts art directly
-        // from the file without fallback resolution (unlike album_art_manager_v2
-        // which can return art from unrelated tracks via its stub/fallback system).
+        // Second try: use album_art_manager_v2 which handles all fb2k path schemes
+        // natively — including mac-volume://UUID for external volumes — and searches
+        // both embedded art and companion files (cover.jpg etc.).
+        //
+        // Bleed-through guard: album_art_manager_v2 can fall back to library-wide
+        // stubs that return art from unrelated tracks. We prevent this by checking
+        // that query_paths() reports a source in the same directory as the track.
+        // Embedded art (no external path) is always accepted.
         if (!image) {
             @try {
                 if (handleCopy.is_valid()) {
-                    const char *path = handleCopy->get_path();
-                    if (path) {
+                    const char *rawPath = handleCopy->get_path();
+                    if (rawPath) {
                         try {
-                            album_art_extractor_instance_ptr extractor =
-                                album_art_extractor::g_open(nullptr, path, fb2k::noAbort);
-                            if (extractor.is_valid()) {
-                                album_art_data::ptr data;
-                                if (extractor->query(album_art_ids::cover_front, data, fb2k::noAbort)) {
+                            auto mgr = album_art_manager_v2::get();
+                            metadb_handle_list handleList;
+                            handleList.add_item(handleCopy);
+                            pfc::list_t<GUID> artIds;
+                            artIds.add_item(album_art_ids::cover_front);
+
+                            album_art_extractor_instance_v2::ptr instance =
+                                mgr->open(handleList, artIds, fb2k::noAbort);
+
+                            // Bleed-through guard: if the manager found art via an
+                            // external file, confirm it lives in the track's directory.
+                            bool accepted = true;
+                            try {
+                                album_art_path_list::ptr paths =
+                                    instance->query_paths(album_art_ids::cover_front,
+                                                          fb2k::noAbort);
+                                if (paths.is_valid() && paths->get_count() > 0) {
+                                    // Find the directory prefix of the track's path.
+                                    const char *lastSlash = strrchr(rawPath, '/');
+                                    if (lastSlash) {
+                                        size_t dirLen = (size_t)(lastSlash - rawPath) + 1;
+                                        accepted = false;
+                                        for (t_size i = 0; i < paths->get_count(); i++) {
+                                            if (strncmp(paths->get_path(i), rawPath, dirLen) == 0) {
+                                                accepted = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                // Empty path list → embedded art → no bleed-through risk
+                            } catch (...) {
+                                accepted = true; // query_paths unavailable → be permissive
+                            }
+
+                            if (accepted) {
+                                try {
+                                    album_art_data::ptr data =
+                                        instance->query(album_art_ids::cover_front, fb2k::noAbort);
                                     if (data.is_valid() && data->size() > 0) {
                                         NSData *imageData = [NSData dataWithBytes:data->data()
                                                                            length:data->size()];
                                         if (imageData) {
                                             image = [[NSImage alloc] initWithData:imageData];
-                                            if (image && (image.size.width > 512 || image.size.height > 512)) {
+                                            if (image && (image.size.width > 512 ||
+                                                          image.size.height > 512)) {
                                                 image = [self resizeImage:image toMaxSize:512];
                                             }
                                         }
                                     }
+                                } catch (...) {
+                                    // No art or unsupported format — not an error
                                 }
                             }
                         } catch (...) {
-                            // No embedded art or unsupported format — not an error
+                            // Manager unavailable
                         }
                     }
                 }
@@ -371,6 +428,49 @@ static NSImage *_placeholderImage = nil;
     NSImage *resizedImage = [[NSImage alloc] initWithSize:newSize];
     [resizedImage addRepresentation:rep];
     return resizedImage;
+}
+
+// Called on the main thread by NSWorkspace when a volume finishes mounting.
+// Purges noImageKeys whose path starts with the mount path so that cover art
+// that failed to load at startup (drive not yet ready) is retried on the next
+// draw cycle instead of staying permanently blacklisted for the session.
+- (void)volumeDidMount:(NSNotification *)notification {
+    NSURL *mountURL = notification.userInfo[NSWorkspaceVolumeURLKey];
+    if (!mountURL) return;
+
+    NSString *mountPath = mountURL.path;
+    if (!mountPath.length) return;
+
+    // POSIX prefix for keys stored as "/Volumes/SSD_EVO2/..." or "file:///Volumes/SSD_EVO2/..."
+    NSString *posixPrefix = [mountPath hasSuffix:@"/"] ? mountPath : [mountPath stringByAppendingString:@"/"];
+
+    // foobar2000 macOS also uses "mac-volume://UUID/..." paths for external volumes.
+    // Fetch the UUID of the newly-mounted volume so we can match those keys too.
+    NSString *volumeUUID = nil;
+    [mountURL getResourceValue:&volumeUUID forKey:NSURLVolumeUUIDStringKey error:nil];
+    NSString *macVolumePrefix = volumeUUID
+        ? [NSString stringWithFormat:@"mac-volume://%@/", volumeUUID]
+        : nil;
+
+    [_pendingLock lock];
+
+    NSMutableArray<NSString *> *staleKeys = [NSMutableArray array];
+    for (NSString *key in _noImageKeys) {
+        if ([key containsString:posixPrefix] ||
+                (macVolumePrefix && [key hasPrefix:macVolumePrefix])) {
+            [staleKeys addObject:key];
+        }
+    }
+
+    if (staleKeys.count > 0) {
+        [_noImageKeys minusSet:[NSSet setWithArray:staleKeys]];
+        [_noImageKeyOrder removeObjectsInArray:staleKeys];
+        FB2K_console_formatter() << "[SimPlaylist] Volume mounted at "
+            << mountPath.UTF8String << " — cleared " << (int)staleKeys.count
+            << " stale noImageKey(s); cover art will be retried.";
+    }
+
+    [_pendingLock unlock];
 }
 
 - (void)clearCache {

--- a/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/AlbumArtCache.mm
@@ -301,19 +301,30 @@ static NSImage *_placeholderImage = nil;
 
                             // Bleed-through guard: if the manager found art via an
                             // external file, confirm it lives in the track's directory.
+                            //
+                            // Strip "file://" before comparing: fb2k get_path() returns
+                            // "file:///Users/..." for local tracks but query_paths() may
+                            // return bare POSIX paths ("/Users/..."). mac-volume:// paths
+                            // are consistent between get_path() and query_paths() so they
+                            // need no adjustment.
                             bool accepted = true;
                             try {
                                 album_art_path_list::ptr paths =
                                     instance->query_paths(album_art_ids::cover_front,
                                                           fb2k::noAbort);
                                 if (paths.is_valid() && paths->get_count() > 0) {
-                                    // Find the directory prefix of the track's path.
-                                    const char *lastSlash = strrchr(rawPath, '/');
+                                    // Normalise track path: strip file:// scheme prefix.
+                                    const char *trackPath = rawPath;
+                                    if (strncmp(trackPath, "file://", 7) == 0) trackPath += 7;
+
+                                    const char *lastSlash = strrchr(trackPath, '/');
                                     if (lastSlash) {
-                                        size_t dirLen = (size_t)(lastSlash - rawPath) + 1;
+                                        size_t dirLen = (size_t)(lastSlash - trackPath) + 1;
                                         accepted = false;
                                         for (t_size i = 0; i < paths->get_count(); i++) {
-                                            if (strncmp(paths->get_path(i), rawPath, dirLen) == 0) {
+                                            const char *artPath = paths->get_path(i);
+                                            if (strncmp(artPath, "file://", 7) == 0) artPath += 7;
+                                            if (strncmp(artPath, trackPath, dirLen) == 0) {
                                                 accepted = true;
                                                 break;
                                             }


### PR DESCRIPTION
If an album's cover art file is named after the album title (e.g. `().jpg` in case of Sigur Rós' () album), SimPlaylist should find it automatically without requiring a conventional name like `cover.jpg`.

## Problem:

The external cover art lookup introduced in #23 checks for image files in the track's directory against a hardcoded list of conventional names (`cover.jpg`, `folder.jpg`, `front.jpg`, etc.). Albums whose art files are named after the album title or artist - a common convention for releases with unusual titles, or art produced by rippers like EAC and dBpoweramp - are never matched by this list, so the file-based lookup finds nothing and the slot falls through to embedded-only extraction or returns no art at all.

## Solution:

Replace the static `coverNames` array with a dynamically built candidate list. The track's cached metadata is read via `get_info_ref()` and used to prepend two metadata-driven patterns before the conventional fallbacks:
- `%album%.ext` - e.g. `().jpg`, `Revolver.png`
- `%artist% - %album%.ext` - e.g. `Sigur Ros - ().jpg`

This directly mirrors the default pattern set used by Windows foobar2000's external art finder. Metadata-derived names are also safer against false positives than a hardcoded list: a file named after the album tag of the track currently playing is far less likely to appear by coincidence in a flat directory of unrelated files than cover.jpg is. The conventional fallbacks remain in place and unchanged, so behaviour for any album that already worked is identical.