### PR TITLE
fix(simplaylist): clear cached Playing column symbol on new track playback

### DIFF
--- a/extensions/foo_jl_simplaylist_mac/src/Core/ColumnDefinition.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/ColumnDefinition.mm
@@ -98,7 +98,28 @@
                     << (columns.count - cleaned.count) << " orphaned custom column(s)";
                 return cleaned;
             }
-            return columns;
+
+        // Migration: remove legacy ">" pattern from Playing columns now that the 
+        // native ▶ drawing in SimPlaylistView handles the indicator.
+        // TODO: This migration for Playing column can be removed in future. Let's keep it until end of 2026.
+        BOOL migrated = NO;
+        NSMutableArray<ColumnDefinition *> *migrating = [cleaned mutableCopy];
+        for (ColumnDefinition *col in migrating) {
+            if ([col.name isEqualToString:@"Playing"] &&
+                [col.pattern isEqualToString:@"$if(%isplaying%,>,)"]) {
+                col.pattern = @"";
+                migrated = YES;
+            }
+        }
+        if (migrated) {
+            NSString *migratedJSON = [self columnsToJSON:migrating];
+            simplaylist_config::setConfigString(
+                simplaylist_config::kColumns, migratedJSON.UTF8String);
+            FB2K_console_formatter() << "[SimPlaylist] Migrated Playing column: removed legacy > pattern";
+            return migrating;
+        }
+
+        return columns;
         }
     }
 
@@ -114,7 +135,7 @@
     // Final fallback to hardcoded defaults
     return @[
         [ColumnDefinition columnWithName:@"Playing"
-                                 pattern:@"$if(%isplaying%,>,)"
+                                 pattern:@""
                                    width:24
                                alignment:ColumnAlignmentCenter],
 
@@ -213,7 +234,7 @@
                                    width:40
                                alignment:ColumnAlignmentCenter],
         [ColumnDefinition columnWithName:@"Playing"
-                                 pattern:@"$if(%isplaying%,>,)"
+                                 pattern:@""
                                    width:24
                                alignment:ColumnAlignmentCenter],
         [ColumnDefinition columnWithName:@"File name"

--- a/extensions/foo_jl_simplaylist_mac/src/Core/ConfigHelper.h
+++ b/extensions/foo_jl_simplaylist_mac/src/Core/ConfigHelper.h
@@ -230,7 +230,7 @@ inline const char* getDefaultGroupPresetsJSON() {
 inline const char* getDefaultColumnsJSON() {
     return R"JSON({
   "columns": [
-    {"name": "Playing", "pattern": "$if(%isplaying%,>,)", "width": 24, "alignment": "center"},
+    {"name": "Playing", "pattern": "", "width": 24, "alignment": "center"},
     {"name": "#", "pattern": "%tracknumber%", "width": 32, "alignment": "right"},
     {"name": "Title", "pattern": "%title%", "width": 250, "alignment": "left", "auto_resize": true},
     {"name": "Artist", "pattern": "%artist%", "width": 150, "alignment": "left", "auto_resize": true},

--- a/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
+++ b/extensions/foo_jl_simplaylist_mac/src/UI/SimPlaylistController.mm
@@ -1924,10 +1924,14 @@ static const NSUInteger kMaxCacheableGroups = 500;
 #pragma mark - Playback Event Handlers
 
 - (void)handlePlaybackNewTrack:(metadb_handle_ptr)track {
+    // Clear cached column values so %isplaying%-based columns (e.g. ">" in the Playing
+    // column) are re-evaluated for the new track rather than showing stale results.
+    [_playlistView clearFormattedValuesCache];
     [self updatePlayingIndicator];
 }
 
 - (void)handlePlaybackStopped {
+    [_playlistView clearFormattedValuesCache];
     _playlistView.playingIndex = -1;
 }
 


### PR DESCRIPTION
If a track changes while SimPlaylist is visible, the Playing column should immediately reflect the new state — showing `▶` only on the track that is actually playing.

## Problem:

The Playing column uses `$if(%isplaying%,>,)` as its pattern, evaluated via `playlist_item_format_title` and stored in `formattedValuesCache` keyed by playlist index. When playback moves to a new track, `handlePlaybackNewTrack:` updates `_playingIndex` and triggers a redraw - but never invalidates the cache. The old track's cached column value still contains `>` and continues to render it, while `_playingIndex` has moved on. The `▶` row indicator and background shading disappear correctly because they are derived live from `_playingIndex` at draw time; only the cached text string is stale.

Separately, the `>` text pattern is a legacy artifact: the native `▶` drawing (`colIndex == 0 && playing` in SimPlaylistView) has existed since the first commit and renders the indicator directly from `_playingIndex` without any caching. The column pattern was never removed, so the Playing column rendered both `▶` and `>` simultaneously.

## Solution:
  
Clear `formattedValuesCache` in `handlePlaybackNewTrack:` and `handlePlaybackStopped:` so `%isplaying%`-dependent column values are re-evaluated against the current playback state on the next draw.

Remove `$if(%isplaying%,>,)` from the Playing column pattern in both hardcoded fallbacks (`ColumnDefinition.mm`) and the JSON default (`ConfigHelper.h`), replacing it with an empty string. The native `▶` drawing remains the sole indicator - it is live, always correct, and renders a proper glyph rather than a plain `>`.

A one-time migration in `defaultColumns` patches any existing saved config that still carries the old pattern, re-saves it, and logs the change to the foobar2000 console. The migration condition is self-expiring and has no ongoing overhead once applied.