### PR TITLE
fix(wave-seekbar): recover from stuck "Analyzing" after layout change

### DIFF
--- a/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformScanner.cpp
+++ b/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformScanner.cpp
@@ -26,10 +26,15 @@ bool WaveformScanner::isScanning() const {
 }
 
 void WaveformScanner::cancel() {
-    if (m_scanning.load()) {
-        m_cancelRequested.store(true);
-        m_abort.abort();
+    std::lock_guard<std::mutex> lock(m_abortMutex);
+    if (m_currentAbort) {
+        m_currentAbort->abort();
+        m_currentAbort.reset();
     }
+    // Bump the generation so the aborted scan stays silent instead of reporting
+    // a failure for a request nobody is waiting on any more.
+    ++m_generation;
+    m_scanning.store(false);
 }
 
 void WaveformScanner::scanAsync(const metadb_handle_ptr& track, WaveformScanCallback callback) {
@@ -42,13 +47,16 @@ void WaveformScanner::scanAsync(const metadb_handle_ptr& track, WaveformScanCall
         return;
     }
 
-    // Cancel any existing scan
+    // Cancel any existing scan, then hand this one its own abort object
     cancel();
 
-    // Reset state with new generation
-    uint64_t gen = ++m_generation;
-    m_cancelRequested.store(false);
-    m_abort.reset();
+    auto abort = std::make_shared<abort_callback_impl>();
+    uint64_t gen;
+    {
+        std::lock_guard<std::mutex> lock(m_abortMutex);
+        m_currentAbort = abort;
+        gen = ++m_generation;
+    }
     m_scanning.store(true);
 
     // Capture track path for the block
@@ -57,40 +65,53 @@ void WaveformScanner::scanAsync(const metadb_handle_ptr& track, WaveformScanCall
 
     // Dispatch to background queue
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        // Check if this scan is still current
-        if (m_generation.load() != gen) return;
-
         std::optional<WaveformData> result;
         const char* error = nullptr;
+        bool aborted = false;
 
-        try {
-            // Re-obtain handle on background thread
-            metadb_handle_ptr handle;
-            metadb::get()->handle_create(handle, make_playable_location(path.c_str(), subsong));
+        // Skip the decode if a newer scan already superseded this one, but still
+        // fall through to the bookkeeping below so m_scanning cannot stick on.
+        if (m_generation.load() == gen) {
+            try {
+                // Re-obtain handle on background thread
+                metadb_handle_ptr handle;
+                metadb::get()->handle_create(handle, make_playable_location(path.c_str(), subsong));
 
-            if (handle.is_valid()) {
-                result = performScan(handle, m_abort);
-                if (!result && !m_cancelRequested.load()) {
-                    error = "Scan failed";
+                if (handle.is_valid()) {
+                    result = performScan(handle, *abort);
+                    if (!result) {
+                        error = "Scan failed";
+                    }
+                } else {
+                    error = "Could not create track handle";
                 }
-            } else {
-                error = "Could not create track handle";
+            } catch (const exception_aborted&) {
+                // Cancelled - not an error
+                aborted = true;
+            } catch (const std::exception& e) {
+                pfc::string_formatter msg;
+                msg << "Scan exception: " << e.what();
+                console::error(msg.c_str());
+                error = "Scan exception";
+            } catch (...) {
+                error = "Unknown scan error";
             }
-        } catch (const exception_aborted&) {
-            // Cancelled - not an error
-        } catch (const std::exception& e) {
-            pfc::string_formatter msg;
-            msg << "Scan exception: " << e.what();
-            console::error(msg.c_str());
-            error = "Scan exception";
-        } catch (...) {
-            error = "Unknown scan error";
         }
 
-        m_scanning.store(false);
+        // Only the scan that still owns m_currentAbort clears the running state;
+        // a superseded scan must not report the newer one as finished.
+        {
+            std::lock_guard<std::mutex> lock(m_abortMutex);
+            if (m_currentAbort == abort) {
+                m_currentAbort.reset();
+                m_scanning.store(false);
+            }
+        }
+
+        if (aborted) return;
 
         // Callback on main thread only if this generation is still current
-        if (callback && m_generation.load() == gen && !m_cancelRequested.load()) {
+        if (callback && m_generation.load() == gen) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 callback(result, error);
             });

--- a/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformScanner.h
+++ b/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformScanner.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <memory>
 #include <atomic>
+#include <mutex>
 
 // Forward declaration for Objective-C compatibility
 #ifdef __OBJC__
@@ -48,11 +49,13 @@ private:
 
     // Atomic state
     std::atomic<bool> m_scanning{false};
-    std::atomic<bool> m_cancelRequested{false};
     std::atomic<uint64_t> m_generation{0};  // Increments per scan to detect stale results
 
-    // Current abort callback for cancellation
-    abort_callback_impl m_abort;
+    // Each scan owns its abort object for its whole lifetime. A shared member
+    // would let a newly started scan reset the flag an older, still-running scan
+    // is about to observe - leaving two decoders racing on one abort_callback.
+    std::mutex m_abortMutex;
+    std::shared_ptr<abort_callback_impl> m_currentAbort;
 };
 
 // Singleton accessor

--- a/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformService.cpp
+++ b/extensions/foo_jl_wave_seekbar_mac/src/Core/WaveformService.cpp
@@ -89,13 +89,15 @@ void WaveformService::requestWaveform(const metadb_handle_ptr& track, WaveformRe
 
     // Scan asynchronously
     m_scanner.scanAsync(track, [this, track, callback](std::optional<WaveformData> result, const char* error) {
-        // Check if this is still the pending track
+        // Clear the pending slot if this result is the one it was waiting for.
+        // The result is delivered either way: listeners filter by track themselves,
+        // and dropping it here used to strand the UI in its "analyzing" state
+        // forever when the pending track was replaced mid-scan (layout reload).
         {
             std::lock_guard<std::mutex> lock(m_pendingMutex);
-            if (!m_pendingTrack.is_valid() || m_pendingTrack->get_location() != track->get_location()) {
-                return;  // Track changed, ignore result
+            if (m_pendingTrack.is_valid() && m_pendingTrack->get_location() == track->get_location()) {
+                m_pendingTrack.release();
             }
-            m_pendingTrack.release();
         }
 
         if (result) {

--- a/extensions/foo_jl_wave_seekbar_mac/src/UI/WaveformSeekbarController.h
+++ b/extensions/foo_jl_wave_seekbar_mac/src/UI/WaveformSeekbarController.h
@@ -27,7 +27,8 @@ struct WaveformData;
 - (void)handlePlaybackPause:(BOOL)paused;
 
 // Waveform data update
-- (void)updateWaveformData:(const WaveformData *)waveform;
+// nullable: a failed or abandoned scan reports "no waveform" with a null pointer
+- (void)updateWaveformData:(nullable const WaveformData *)waveform;
 
 @end
 

--- a/extensions/foo_jl_wave_seekbar_mac/src/UI/WaveformSeekbarController.mm
+++ b/extensions/foo_jl_wave_seekbar_mac/src/UI/WaveformSeekbarController.mm
@@ -25,6 +25,8 @@
     BOOL _heightLocked;                             // Track if height is locked
     ListenerId _waveformListenerId;                 // For safe listener removal
     NSVisualEffectView *_glassEffectView;           // Blur background when glass mode is on
+    NSTimer *_analysisWatchdog;                     // Breaks a stuck "Analyzing..." state
+    int _analysisRetries;                           // Re-requests already spent on this track
 }
 
 @property (nonatomic, readwrite) WaveformSeekbarView *waveformView;
@@ -143,6 +145,21 @@
     [self syncWithCurrentPlayback];
 }
 
+- (void)viewDidAppear {
+    [super viewDidAppear];
+
+    // A layout change tears this element down and builds a fresh one. If the
+    // scan for the current track was already in flight, its result went to the
+    // controller that requested it, so this instance would sit on "Analyzing..."
+    // until the next track. Re-request whenever we appear without a waveform.
+    if (!_storedWaveform && !_currentTrack.is_valid()) {
+        [self syncWithCurrentPlayback];
+    } else if (!_storedWaveform && _currentTrack.is_valid()) {
+        getWaveformService().requestWaveform(_currentTrack, nullptr);
+        [self startAnalysisWatchdog];
+    }
+}
+
 - (void)viewWillDisappear {
     [super viewWillDisappear];
     [self stopPositionTimer];
@@ -150,6 +167,7 @@
 
 - (void)dealloc {
     [self stopPositionTimer];
+    [self stopAnalysisWatchdog];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     PlaybackCallbackManager::instance().unregisterController(self);
     // Remove only our listener from the waveform service
@@ -209,7 +227,9 @@
 
     // Request waveform
     if (track.is_valid()) {
+        _analysisRetries = 0;
         getWaveformService().requestWaveform(track, nullptr);
+        [self startAnalysisWatchdog];
     }
 
     // Start timer for smooth position updates
@@ -222,6 +242,7 @@
     _storedWaveform.reset();  // Release stored waveform
 
     [self stopPositionTimer];
+    [self stopAnalysisWatchdog];
 
     self.waveformView.trackDuration = 0.0;
     self.waveformView.playbackPosition = 0.0;
@@ -260,6 +281,7 @@
 
 - (void)updateWaveformData:(const WaveformData *)waveform {
     self.waveformView.analyzing = NO;  // Analysis complete
+    [self stopAnalysisWatchdog];
 
     if (!waveform || !waveform->isValid()) {
         _storedWaveform.reset();
@@ -272,6 +294,47 @@
     }
 
     [self.waveformView refreshDisplay];
+}
+
+#pragma mark - Analysis Watchdog
+
+// Longest a scan is allowed to run before we assume its result is never coming.
+// Generous enough for a long track on a slow or network volume.
+static const NSTimeInterval kAnalysisTimeout = 30.0;
+static const int kAnalysisMaxRetries = 1;
+
+- (void)startAnalysisWatchdog {
+    [self stopAnalysisWatchdog];
+
+    __weak typeof(self) weakSelf = self;
+    _analysisWatchdog = [NSTimer scheduledTimerWithTimeInterval:kAnalysisTimeout
+                                                        repeats:NO
+                                                          block:^(NSTimer * _Nonnull timer) {
+        [weakSelf handleAnalysisTimeout];
+    }];
+}
+
+- (void)stopAnalysisWatchdog {
+    [_analysisWatchdog invalidate];
+    _analysisWatchdog = nil;
+}
+
+- (void)handleAnalysisTimeout {
+    _analysisWatchdog = nil;
+
+    if (!self.waveformView.analyzing) return;
+
+    if (_currentTrack.is_valid() && _analysisRetries < kAnalysisMaxRetries) {
+        _analysisRetries++;
+        FB2K_console_formatter() << "[WaveSeek] Analysis timed out, re-requesting waveform";
+        getWaveformService().requestWaveform(_currentTrack, nullptr);
+        [self startAnalysisWatchdog];
+        return;
+    }
+
+    // Give up rather than latch on "Analyzing..." indefinitely
+    FB2K_console_formatter() << "[WaveSeek] Analysis timed out, giving up on this track";
+    [self updateWaveformData:nullptr];
 }
 
 #pragma mark - Position Timer


### PR DESCRIPTION
Applying a layout while a track plays rebuilds the UI element with a scan already in flight. The result was then discarded on three separate paths, latching the seekbar on `Analyzing... `until the app was restarted:

- `WaveformService` dropped a completed scan when `m_pendingTrack` no longer matched, returning before caching it and before notifying listeners. The rebuilt element re-requests the same track, rewriting the pending slot and orphaning the running scan. Listeners already filter by track, so always cache and always notify.
- `WaveformScanner` returned early on a generation mismatch without clearing `m_scanning`, leaving the flag stuck on for the process lifetime. Only the scan that still owns the current abort now clears it.
- A single `abort_callback_impl` member was shared by overlapping scans, so starting one scan called `reset()` while an older decode was still inside `decoder.run()`. Each scan now owns its abort object for its full lifetime, and `cancel()` bumps the generation so an aborted scan stays silent.

Also adds a 30s analysis watchdog (one re-request, then fall back to `No waveform`) and a `viewDidAppear` re-request, so a rebuilt element recovers without waiting for the next track. `Analyzing...` can no longer be terminal.

Confirmed against the original repro: waveform now draws immediately after applying a layout mid-playback.

// TL;DR if you were applying new layouts, `waveform-seekbar` was broken until restarting the application (encountered on macOS 15 Sequioa)