### PR TITLE
feat: new component - Spectrum Analyzer (foo_jl_spectrum_mac)

### DIFF
--- a/extensions/foo_jl_spectrum_mac/.gitignore
+++ b/extensions/foo_jl_spectrum_mac/.gitignore
@@ -1,0 +1,32 @@
+# Xcode
+build/
+DerivedData/
+*.xcworkspace
+xcuserdata/
+*.xccheckout
+*.xcodeproj/
+
+# Build artifacts
+*.component
+*.o
+*.a
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# IDE
+.idea/
+*.swp
+*.swo
+
+# Xcode project user data
+*.xcuserstate
+*.xcuserdata
+*.xcscmblueprint
+*.xcscheme
+
+# Backup files
+*~
+*.bak

--- a/extensions/foo_jl_spectrum_mac/LICENSE
+++ b/extensions/foo_jl_spectrum_mac/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 foo_jl_spectrum_mac contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/foo_jl_spectrum_mac/Resources/Info.plist
+++ b/extensions/foo_jl_spectrum_mac/Resources/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.foobar2000.foo-jl-spectrum</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Spectrum Analyzer</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2025 Jenda Legenda. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+	<key>NSAccessibilityRole</key>
+	<string>AXGroup</string>
+</dict>
+</plist>

--- a/extensions/foo_jl_spectrum_mac/Scripts/build.sh
+++ b/extensions/foo_jl_spectrum_mac/Scripts/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# build.sh - Build foo_jl_spectrum component
+#
+# Usage:
+#   ./Scripts/build.sh [OPTIONS]
+#
+# Options:
+#   --debug       Build Debug configuration (default: Release)
+#   --release     Build Release configuration
+#   --clean       Clean before building
+#   --regenerate  Regenerate Xcode project before building
+#   --install     Install to foobar2000 after building
+#   --help        Show this help message
+
+set -e
+
+# Component configuration
+PROJECT_NAME="foo_jl_spectrum"
+
+# Load shared library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/../../../shared/scripts/lib.sh"
+
+show_help() {
+    head -16 "$0" | tail -12
+    exit 0
+}
+
+# Parse arguments
+if ! parse_build_args "$@"; then
+    show_help
+fi
+
+# Build options
+BUILD_OPTS=""
+[ "$CLEAN_FIRST" = true ] && BUILD_OPTS="$BUILD_OPTS --clean"
+[ "$REGENERATE" = true ] && BUILD_OPTS="$BUILD_OPTS --regenerate"
+
+# Run build
+if do_build $BUILD_OPTS; then
+    # Install if requested
+    if [ "$INSTALL_AFTER" = true ]; then
+        do_install
+    fi
+else
+    exit 1
+fi

--- a/extensions/foo_jl_spectrum_mac/Scripts/clean.sh
+++ b/extensions/foo_jl_spectrum_mac/Scripts/clean.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# clean.sh - Clean foo_jl_spectrum build artifacts
+#
+# Usage:
+#   ./Scripts/clean.sh
+
+set -e
+
+# Component configuration
+PROJECT_NAME="foo_jl_spectrum"
+
+# Load shared library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/../../../shared/scripts/lib.sh"
+
+# Run clean
+do_clean

--- a/extensions/foo_jl_spectrum_mac/Scripts/generate_xcode_project.rb
+++ b/extensions/foo_jl_spectrum_mac/Scripts/generate_xcode_project.rb
@@ -1,0 +1,612 @@
+#!/usr/bin/env ruby
+# Generate Xcode project for foo_jl_spectrum_mac
+
+require 'fileutils'
+require 'securerandom'
+require_relative '../../../shared/sdk_config'
+
+# Generate UUID for Xcode (24 character hex string)
+def generate_uuid
+  SecureRandom.hex(12).upcase
+end
+
+# Project configuration
+PROJECT_NAME = "foo_jl_spectrum"
+BUNDLE_ID = "com.foobar2000.foo-jl-spectrum"
+SDK_PATH = Fb2kSdk.path
+
+# Version from shared/version.h (single source of truth)
+COMPONENT_VERSION = Fb2kVersions.get("spectrum")
+BUILD_NUMBER = Fb2kVersions.get_build_number("spectrum")
+
+# Generate all the UUIDs we'll need
+uuid_project = generate_uuid
+uuid_main_group = generate_uuid
+uuid_products_group = generate_uuid
+uuid_target = generate_uuid
+uuid_native_target = generate_uuid
+uuid_build_config_list_project = generate_uuid
+uuid_build_config_list_target = generate_uuid
+uuid_debug_config_project = generate_uuid
+uuid_release_config_project = generate_uuid
+uuid_debug_config_target = generate_uuid
+uuid_release_config_target = generate_uuid
+uuid_sources_build_phase = generate_uuid
+uuid_frameworks_build_phase = generate_uuid
+uuid_resources_build_phase = generate_uuid
+uuid_product = generate_uuid
+
+# Source file groups
+uuid_src_group = generate_uuid
+uuid_core_group = generate_uuid
+uuid_ui_group = generate_uuid
+uuid_integration_group = generate_uuid
+uuid_resources_group = generate_uuid
+
+# Framework references
+uuid_cocoa_framework = generate_uuid
+uuid_cocoa_framework_ref = generate_uuid
+uuid_quartz_framework = generate_uuid
+uuid_quartz_framework_ref = generate_uuid
+uuid_accelerate_framework = generate_uuid
+uuid_accelerate_framework_ref = generate_uuid
+uuid_security_framework = generate_uuid
+uuid_security_framework_ref = generate_uuid
+uuid_sqlite_lib = generate_uuid
+uuid_sqlite_lib_ref = generate_uuid
+uuid_compression_lib = generate_uuid
+uuid_compression_lib_ref = generate_uuid
+uuid_zlib = generate_uuid
+uuid_zlib_ref = generate_uuid
+uuid_frameworks_group = generate_uuid
+
+# SDK libraries
+uuid_sdk_lib = generate_uuid
+uuid_sdk_lib_ref = generate_uuid
+uuid_helpers_lib = generate_uuid
+uuid_helpers_lib_ref = generate_uuid
+uuid_component_client_lib = generate_uuid
+uuid_component_client_lib_ref = generate_uuid
+uuid_shared_lib = generate_uuid
+uuid_shared_lib_ref = generate_uuid
+uuid_pfc_lib = generate_uuid
+uuid_pfc_lib_ref = generate_uuid
+
+# Collect source files
+core_files = Dir.glob("src/Core/*.{cpp,h,mm}").map { |f| File.basename(f) }
+ui_files = Dir.glob("src/UI/*.{cpp,h,mm}").map { |f| File.basename(f) }
+integration_files = Dir.glob("src/Integration/*.{cpp,h,mm}").map { |f| File.basename(f) }
+
+# Collect resource files (XIB, etc.)
+resource_files = Dir.glob("Resources/*.xib").map { |f| File.basename(f) }
+
+# Generate UUIDs for all source files
+file_uuids = {}
+file_ref_uuids = {}
+
+[core_files, ui_files, integration_files].flatten.each do |file|
+  file_uuids[file] = generate_uuid
+  file_ref_uuids[file] = generate_uuid
+end
+
+# Generate UUIDs for resource files
+resource_files.each do |file|
+  file_uuids[file] = generate_uuid
+  file_ref_uuids[file] = generate_uuid
+end
+
+# Info.plist UUID
+uuid_infoplist = generate_uuid
+
+puts "Generating Xcode project structure..."
+puts "  Core files: #{core_files.join(', ')}"
+puts "  UI files: #{ui_files.join(', ')}"
+puts "  Integration files: #{integration_files.join(', ')}"
+puts "  Resource files: #{resource_files.join(', ')}"
+
+# Create the .xcodeproj bundle
+FileUtils.mkdir_p("#{PROJECT_NAME}.xcodeproj")
+
+# Generate project.pbxproj file
+pbxproj_content = <<~PBXPROJ
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+PBXPROJ
+
+# Add build file entries for source files
+[['Core', core_files], ['UI', ui_files], ['Integration', integration_files]].each do |group, files|
+  files.each do |file|
+    next if file.end_with?('.h')  # Don't compile headers
+    pbxproj_content += "\t\t#{file_uuids[file]} /* #{file} in Sources */ = {isa = PBXBuildFile; fileRef = #{file_ref_uuids[file]} /* #{file} */; };\n"
+  end
+end
+
+# Add XIB files as resources
+resource_files.each do |file|
+  pbxproj_content += "\t\t#{file_uuids[file]} /* #{file} in Resources */ = {isa = PBXBuildFile; fileRef = #{file_ref_uuids[file]} /* #{file} */; };\n"
+end
+
+# Add frameworks
+pbxproj_content += "\t\t#{uuid_cocoa_framework} /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_cocoa_framework_ref} /* Cocoa.framework */; };\n"
+pbxproj_content += "\t\t#{uuid_quartz_framework} /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_quartz_framework_ref} /* QuartzCore.framework */; };\n"
+pbxproj_content += "\t\t#{uuid_accelerate_framework} /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_accelerate_framework_ref} /* Accelerate.framework */; };\n"
+pbxproj_content += "\t\t#{uuid_security_framework} /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_security_framework_ref} /* Security.framework */; };\n"
+pbxproj_content += "\t\t#{uuid_sqlite_lib} /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_sqlite_lib_ref} /* libsqlite3.tbd */; };\n"
+pbxproj_content += "\t\t#{uuid_compression_lib} /* libcompression.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_compression_lib_ref} /* libcompression.tbd */; };\n"
+pbxproj_content += "\t\t#{uuid_zlib} /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_zlib_ref} /* libz.tbd */; };\n"
+
+# Add SDK libraries
+pbxproj_content += "\t\t#{uuid_sdk_lib} /* libfoobar2000_SDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_sdk_lib_ref} /* libfoobar2000_SDK.a */; };\n"
+pbxproj_content += "\t\t#{uuid_helpers_lib} /* libfoobar2000_SDK_helpers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_helpers_lib_ref} /* libfoobar2000_SDK_helpers.a */; };\n"
+pbxproj_content += "\t\t#{uuid_component_client_lib} /* libfoobar2000_component_client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_component_client_lib_ref} /* libfoobar2000_component_client.a */; };\n"
+pbxproj_content += "\t\t#{uuid_shared_lib} /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_shared_lib_ref} /* libshared.a */; };\n"
+pbxproj_content += "\t\t#{uuid_pfc_lib} /* libpfc-Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = #{uuid_pfc_lib_ref} /* libpfc-Mac.a */; };\n"
+
+pbxproj_content += <<~PBXPROJ
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+PBXPROJ
+
+# Add file references for source files
+[['Core', core_files], ['UI', ui_files], ['Integration', integration_files]].each do |group, files|
+  files.each do |file|
+    file_type = if file.end_with?('.h')
+      'sourcecode.c.h'
+    elsif file.end_with?('.mm')
+      'sourcecode.cpp.objcpp'
+    elsif file.end_with?('.cpp')
+      'sourcecode.cpp.cpp'
+    else
+      'text'
+    end
+
+    pbxproj_content += "\t\t#{file_ref_uuids[file]} /* #{file} */ = {isa = PBXFileReference; lastKnownFileType = #{file_type}; path = #{file}; sourceTree = \"<group>\"; };\n"
+  end
+end
+
+# Add XIB file references
+resource_files.each do |file|
+  pbxproj_content += "\t\t#{file_ref_uuids[file]} /* #{file} */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = #{file}; sourceTree = \"<group>\"; };\n"
+end
+
+# Add product reference
+pbxproj_content += "\t\t#{uuid_product} /* #{PROJECT_NAME}.component */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = #{PROJECT_NAME}.component; sourceTree = BUILT_PRODUCTS_DIR; };\n"
+
+# Add Info.plist reference
+pbxproj_content += "\t\t#{uuid_infoplist} /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = \"<group>\"; };\n"
+
+# Add framework references
+pbxproj_content += "\t\t#{uuid_cocoa_framework_ref} /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_quartz_framework_ref} /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_accelerate_framework_ref} /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_security_framework_ref} /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_sqlite_lib_ref} /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = \"sourcecode.text-based-dylib-definition\"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_compression_lib_ref} /* libcompression.tbd */ = {isa = PBXFileReference; lastKnownFileType = \"sourcecode.text-based-dylib-definition\"; name = libcompression.tbd; path = usr/lib/libcompression.tbd; sourceTree = SDKROOT; };\n"
+pbxproj_content += "\t\t#{uuid_zlib_ref} /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = \"sourcecode.text-based-dylib-definition\"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };\n"
+
+# Add SDK library references
+pbxproj_content += "\t\t#{uuid_sdk_lib_ref} /* libfoobar2000_SDK.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfoobar2000_SDK.a; path = \"#{SDK_PATH}/foobar2000/SDK/build/Release/libfoobar2000_SDK.a\"; sourceTree = \"<group>\"; };\n"
+pbxproj_content += "\t\t#{uuid_helpers_lib_ref} /* libfoobar2000_SDK_helpers.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfoobar2000_SDK_helpers.a; path = \"#{SDK_PATH}/foobar2000/helpers/build/Release/libfoobar2000_SDK_helpers.a\"; sourceTree = \"<group>\"; };\n"
+pbxproj_content += "\t\t#{uuid_component_client_lib_ref} /* libfoobar2000_component_client.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfoobar2000_component_client.a; path = \"#{SDK_PATH}/foobar2000/foobar2000_component_client/build/Release/libfoobar2000_component_client.a\"; sourceTree = \"<group>\"; };\n"
+pbxproj_content += "\t\t#{uuid_shared_lib_ref} /* libshared.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libshared.a; path = \"#{SDK_PATH}/foobar2000/shared/build/Release/libshared.a\"; sourceTree = \"<group>\"; };\n"
+pbxproj_content += "\t\t#{uuid_pfc_lib_ref} /* libpfc-Mac.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = \"libpfc-Mac.a\"; path = \"#{SDK_PATH}/pfc/build/Release/libpfc-Mac.a\"; sourceTree = \"<group>\"; };\n"
+
+pbxproj_content += <<~PBXPROJ
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		#{uuid_frameworks_build_phase} /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				#{uuid_cocoa_framework} /* Cocoa.framework in Frameworks */,
+				#{uuid_quartz_framework} /* QuartzCore.framework in Frameworks */,
+				#{uuid_accelerate_framework} /* Accelerate.framework in Frameworks */,
+				#{uuid_security_framework} /* Security.framework in Frameworks */,
+				#{uuid_sqlite_lib} /* libsqlite3.tbd in Frameworks */,
+				#{uuid_compression_lib} /* libcompression.tbd in Frameworks */,
+				#{uuid_zlib} /* libz.tbd in Frameworks */,
+				#{uuid_sdk_lib} /* libfoobar2000_SDK.a in Frameworks */,
+				#{uuid_helpers_lib} /* libfoobar2000_SDK_helpers.a in Frameworks */,
+				#{uuid_component_client_lib} /* libfoobar2000_component_client.a in Frameworks */,
+				#{uuid_shared_lib} /* libshared.a in Frameworks */,
+				#{uuid_pfc_lib} /* libpfc-Mac.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		#{uuid_project} = {
+			isa = PBXGroup;
+			children = (
+				#{uuid_src_group} /* src */,
+				#{uuid_resources_group} /* Resources */,
+				#{uuid_frameworks_group} /* Frameworks */,
+				#{uuid_products_group} /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		#{uuid_src_group} /* src */ = {
+			isa = PBXGroup;
+			children = (
+				#{uuid_core_group} /* Core */,
+				#{uuid_ui_group} /* UI */,
+				#{uuid_integration_group} /* Integration */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		#{uuid_core_group} /* Core */ = {
+			isa = PBXGroup;
+			children = (
+PBXPROJ
+
+core_files.each do |file|
+  pbxproj_content += "\t\t\t\t#{file_ref_uuids[file]} /* #{file} */,\n"
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		#{uuid_ui_group} /* UI */ = {
+			isa = PBXGroup;
+			children = (
+PBXPROJ
+
+ui_files.each do |file|
+  pbxproj_content += "\t\t\t\t#{file_ref_uuids[file]} /* #{file} */,\n"
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+		#{uuid_integration_group} /* Integration */ = {
+			isa = PBXGroup;
+			children = (
+PBXPROJ
+
+integration_files.each do |file|
+  pbxproj_content += "\t\t\t\t#{file_ref_uuids[file]} /* #{file} */,\n"
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			path = Integration;
+			sourceTree = "<group>";
+		};
+		#{uuid_resources_group} /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				#{uuid_infoplist} /* Info.plist */,
+PBXPROJ
+
+resource_files.each do |file|
+  pbxproj_content += "\t\t\t\t#{file_ref_uuids[file]} /* #{file} */,\n"
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		#{uuid_frameworks_group} /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				#{uuid_cocoa_framework_ref} /* Cocoa.framework */,
+				#{uuid_quartz_framework_ref} /* QuartzCore.framework */,
+				#{uuid_accelerate_framework_ref} /* Accelerate.framework */,
+				#{uuid_security_framework_ref} /* Security.framework */,
+				#{uuid_sqlite_lib_ref} /* libsqlite3.tbd */,
+				#{uuid_compression_lib_ref} /* libcompression.tbd */,
+				#{uuid_zlib_ref} /* libz.tbd */,
+				#{uuid_sdk_lib_ref} /* libfoobar2000_SDK.a */,
+				#{uuid_helpers_lib_ref} /* libfoobar2000_SDK_helpers.a */,
+				#{uuid_component_client_lib_ref} /* libfoobar2000_component_client.a */,
+				#{uuid_shared_lib_ref} /* libshared.a */,
+				#{uuid_pfc_lib_ref} /* libpfc-Mac.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		#{uuid_products_group} /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				#{uuid_product} /* #{PROJECT_NAME}.component */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		#{uuid_native_target} /* #{PROJECT_NAME} */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = #{uuid_build_config_list_target} /* Build configuration list for PBXNativeTarget "#{PROJECT_NAME}" */;
+			buildPhases = (
+				#{uuid_sources_build_phase} /* Sources */,
+				#{uuid_frameworks_build_phase} /* Frameworks */,
+				#{uuid_resources_build_phase} /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = #{PROJECT_NAME};
+			productName = #{PROJECT_NAME};
+			productReference = #{uuid_product} /* #{PROJECT_NAME}.component */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		#{uuid_target} /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					#{uuid_native_target} = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = #{uuid_build_config_list_project} /* Build configuration list for PBXProject "#{PROJECT_NAME}" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = #{uuid_project};
+			productRefGroup = #{uuid_products_group} /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				#{uuid_native_target} /* #{PROJECT_NAME} */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		#{uuid_resources_build_phase} /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+PBXPROJ
+
+# Add XIB files to resources
+resource_files.each do |file|
+  pbxproj_content += "\t\t\t\t#{file_uuids[file]} /* #{file} in Resources */,\n"
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		#{uuid_sources_build_phase} /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+PBXPROJ
+
+# Add all source files (not headers) to sources build phase
+[['Core', core_files], ['UI', ui_files], ['Integration', integration_files]].each do |group, files|
+  files.each do |file|
+    next if file.end_with?('.h')
+    pbxproj_content += "\t\t\t\t#{file_uuids[file]} /* #{file} in Sources */,\n"
+  end
+end
+
+pbxproj_content += <<~PBXPROJ
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		#{uuid_debug_config_project} /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		#{uuid_release_config_project} /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		#{uuid_debug_config_target} /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = #{BUILD_NUMBER};
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Resources/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = #{COMPONENT_VERSION};
+				PRODUCT_BUNDLE_IDENTIFIER = #{BUNDLE_ID};
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = component;
+				GCC_PREFIX_HEADER = src/Prefix.pch;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/#{SDK_PATH}",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000",
+					"$(PROJECT_DIR)/#{SDK_PATH}/pfc",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/SDK/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/helpers/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/foobar2000_component_client/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/shared/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/pfc/build/Release",
+				);
+			};
+			name = Debug;
+		};
+		#{uuid_release_config_target} /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = #{BUILD_NUMBER};
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Resources/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = #{COMPONENT_VERSION};
+				PRODUCT_BUNDLE_IDENTIFIER = #{BUNDLE_ID};
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = component;
+				GCC_PREFIX_HEADER = src/Prefix.pch;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/#{SDK_PATH}",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000",
+					"$(PROJECT_DIR)/#{SDK_PATH}/pfc",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/SDK/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/helpers/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/foobar2000_component_client/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/foobar2000/shared/build/Release",
+					"$(PROJECT_DIR)/#{SDK_PATH}/pfc/build/Release",
+				);
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		#{uuid_build_config_list_project} /* Build configuration list for PBXProject "#{PROJECT_NAME}" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				#{uuid_debug_config_project} /* Debug */,
+				#{uuid_release_config_project} /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		#{uuid_build_config_list_target} /* Build configuration list for PBXNativeTarget "#{PROJECT_NAME}" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				#{uuid_debug_config_target} /* Debug */,
+				#{uuid_release_config_target} /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = #{uuid_target} /* Project object */;
+}
+PBXPROJ
+
+# Write the project file
+File.write("#{PROJECT_NAME}.xcodeproj/project.pbxproj", pbxproj_content)
+
+puts ""
+puts "Xcode project generated successfully!"
+puts "   Project: #{PROJECT_NAME}.xcodeproj"
+puts "   Target: #{PROJECT_NAME}"
+puts "   Product: #{PROJECT_NAME}.component"
+puts ""
+puts "Next steps:"
+puts "   1. Build SDK libraries (if not already done)"
+puts "   2. Open #{PROJECT_NAME}.xcodeproj in Xcode"
+puts "   3. Build (Cmd+B)"

--- a/extensions/foo_jl_spectrum_mac/Scripts/install.sh
+++ b/extensions/foo_jl_spectrum_mac/Scripts/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# install.sh - Install foo_jl_spectrum to foobar2000
+#
+# Usage:
+#   ./Scripts/install.sh [OPTIONS]
+#
+# Options:
+#   --config CONFIG  Use specified build configuration (Debug/Release, default: Release)
+#   --help           Show this help message
+
+set -e
+
+# Component configuration
+PROJECT_NAME="foo_jl_spectrum"
+
+# Load shared library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/../../../shared/scripts/lib.sh"
+
+show_help() {
+    head -12 "$0" | tail -8
+    exit 0
+}
+
+# Parse arguments
+if ! parse_install_args "$@"; then
+    show_help
+fi
+
+# Run install
+do_install

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
@@ -155,7 +155,8 @@ bool SpectrumAnalyzer::tick() {
             int lo = _binLo[i];
             int hi = _binHi[i];
             if (hi >= binCount) hi = binCount - 1;
-            if (lo > hi) { /* keep previous target of 0 */ }
+            // If the clamp leaves lo > hi, the band loop runs zero times and
+            // the bar decays toward a zero target.
 
             // Peak magnitude across the band (peak reads punchier than average).
             float mag = 0.0f;

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
@@ -47,6 +47,7 @@ void SpectrumAnalyzer::configure(const SpectrumAnalyzer::Settings& settings) {
 
     const size_t n = static_cast<size_t>(_settings.barCount);
     _bars.assign(n, 0.0f);
+    _shadow.assign(n, 0.0f);
     _peaks.assign(n, 0.0f);
     _peakVel.assign(n, 0.0f);
     _bandsDirty = true;  // bin ranges depend on sample rate, computed lazily
@@ -177,9 +178,17 @@ bool SpectrumAnalyzer::tick() {
         }
     }
 
-    // Falling peak caps with gravity.
     bool anyActive = false;
     for (int i = 0; i < bars; ++i) {
+        // Slow-decaying shadow fill: jumps up with the bar, eases down slower.
+        if (_bars[i] >= _shadow[i]) {
+            _shadow[i] = _bars[i];
+        } else {
+            _shadow[i] *= 0.90f;
+            if (_shadow[i] < _bars[i]) _shadow[i] = _bars[i];
+        }
+
+        // Falling peak caps with gravity.
         if (_bars[i] > _peaks[i]) {
             _peaks[i] = _bars[i];
             _peakVel[i] = 0.0f;
@@ -189,7 +198,8 @@ bool SpectrumAnalyzer::tick() {
             if (_peaks[i] < _bars[i]) { _peaks[i] = _bars[i]; _peakVel[i] = 0.0f; }
             if (_peaks[i] < 0.0f) _peaks[i] = 0.0f;
         }
-        if (_bars[i] > 0.0f || _peaks[i] > 0.0f) anyActive = true;
+
+        if (_bars[i] > 0.0f || _peaks[i] > 0.0f || _shadow[i] > 0.0f) anyActive = true;
     }
 
     _active = anyActive;
@@ -203,6 +213,7 @@ void SpectrumAnalyzer::suspend() {
     // stream returns no data for its first reads and would never warm up.)
     releaseStream();
     std::fill(_bars.begin(), _bars.end(), 0.0f);
+    std::fill(_shadow.begin(), _shadow.end(), 0.0f);
     std::fill(_peaks.begin(), _peaks.end(), 0.0f);
     std::fill(_peakVel.begin(), _peakVel.end(), 0.0f);
     _active = false;

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
@@ -1,0 +1,209 @@
+//
+//  SpectrumAnalyzer.cpp
+//  foo_jl_spectrum_mac
+//
+
+#include "SpectrumAnalyzer.h"
+#include "SpectrumConfig.h"
+#include <cmath>
+#include <algorithm>
+
+namespace {
+    // Convert a normalized magnitude (0..1 from KStreamFlagNewFFT) into a
+    // display value by mapping a dB window to 0..1. This gives the familiar
+    // spectrum-analyzer look where quiet detail is still visible.
+    inline float magnitudeToDisplay(float mag) {
+        if (mag <= 1e-7f) return 0.0f;
+        float db = 20.0f * std::log10(mag);
+        float v = (db - spectrum_config::kDisplayFloorDb) /
+                  (spectrum_config::kDisplayCeilDb - spectrum_config::kDisplayFloorDb);
+        if (v < 0.0f) v = 0.0f;
+        if (v > 1.0f) v = 1.0f;
+        return v;
+    }
+
+    inline int nextPow2(int v) {
+        int p = 1;
+        while (p < v) p <<= 1;
+        return p;
+    }
+}
+
+SpectrumAnalyzer::SpectrumAnalyzer() {
+    configure(Settings{});
+}
+
+void SpectrumAnalyzer::configure(const SpectrumAnalyzer::Settings& settings) {
+    _settings = settings;
+
+    // Sanitize
+    if (_settings.barCount < 4)   _settings.barCount = 4;
+    if (_settings.barCount > 512) _settings.barCount = 512;
+    _settings.fftSize = nextPow2(std::max(256, std::min(_settings.fftSize, 32768)));
+    if (_settings.minHz < 10)     _settings.minHz = 10;
+    if (_settings.maxHz <= _settings.minHz + 100) _settings.maxHz = _settings.minHz + 100;
+    if (_settings.smoothing < 0)   _settings.smoothing = 0;
+    if (_settings.smoothing > 100) _settings.smoothing = 100;
+
+    const size_t n = static_cast<size_t>(_settings.barCount);
+    _bars.assign(n, 0.0f);
+    _peaks.assign(n, 0.0f);
+    _peakVel.assign(n, 0.0f);
+    _bandsDirty = true;  // bin ranges depend on sample rate, computed lazily
+}
+
+void SpectrumAnalyzer::releaseStream() {
+    _stream.release();
+}
+
+void SpectrumAnalyzer::rebuildBands() {
+    const int bars = _settings.barCount;
+    const int fftSize = _settings.fftSize;
+    const int binCount = fftSize / 2;               // magnitude bins available
+    const double sr = _lastSampleRate > 0 ? _lastSampleRate : 44100.0;
+    const double nyquist = sr * 0.5;
+
+    _binLo.assign(bars, 0);
+    _binHi.assign(bars, 0);
+
+    const double minHz = std::min<double>(_settings.minHz, nyquist - 1);
+    const double maxHz = std::min<double>(_settings.maxHz, nyquist);
+    const double hzPerBin = sr / fftSize;
+
+    for (int i = 0; i < bars; ++i) {
+        double f0, f1;
+        if (_settings.logScale) {
+            const double logMin = std::log10(minHz);
+            const double logMax = std::log10(maxHz);
+            f0 = std::pow(10.0, logMin + (logMax - logMin) * (double)i / bars);
+            f1 = std::pow(10.0, logMin + (logMax - logMin) * (double)(i + 1) / bars);
+        } else {
+            f0 = minHz + (maxHz - minHz) * (double)i / bars;
+            f1 = minHz + (maxHz - minHz) * (double)(i + 1) / bars;
+        }
+
+        int lo = (int)std::floor(f0 / hzPerBin);
+        int hi = (int)std::ceil(f1 / hzPerBin) - 1;
+
+        // Ensure every bar covers at least one bin and stays in range.
+        if (hi < lo) hi = lo;
+        if (lo < 1) lo = 1;                          // skip DC bin
+        if (hi >= binCount) hi = binCount - 1;
+        if (lo > hi) lo = hi;
+
+        _binLo[i] = lo;
+        _binHi[i] = hi;
+    }
+
+    _bandsDirty = false;
+}
+
+bool SpectrumAnalyzer::tick() {
+    // Smoothing coefficient: fraction of the previous value retained per frame.
+    // attack is faster than decay so bars rise quickly and fall smoothly.
+    const float s = _settings.smoothing / 100.0f;
+    const float decayKeep  = 0.60f + 0.39f * s;   // ~0.60 .. 0.99
+    const float attackKeep = 0.10f + 0.50f * s;   // ~0.10 .. 0.60
+
+    audio_chunk_impl spectrum;
+    bool gotData = false;
+
+    try {
+        if (_stream.is_empty()) {
+            auto vm = visualisation_manager::get();
+            if (vm.is_valid()) {
+                vm->create_stream(_stream, visualisation_manager::KStreamFlagNewFFT);
+                if (_stream.is_valid()) {
+                    _stream->set_channel_mode(visualisation_stream_v2::channel_mode_mono);
+                }
+            }
+        }
+
+        if (_stream.is_valid()) {
+            double t = 0;
+            if (_stream->get_absolute_time(t)) {
+                if (_stream->get_spectrum_absolute(spectrum, t, _settings.fftSize)) {
+                    gotData = true;
+                }
+            }
+        }
+    } catch (...) {
+        gotData = false;
+    }
+
+    const int bars = _settings.barCount;
+
+    if (gotData) {
+        const double sr = spectrum.get_sample_rate();
+        if (sr > 0 && sr != _lastSampleRate) {
+            _lastSampleRate = sr;
+            _bandsDirty = true;
+        }
+        if (_bandsDirty) rebuildBands();
+
+        const audio_sample* data = spectrum.get_data();
+        const unsigned channels = spectrum.get_channel_count();
+        const t_size frames = spectrum.get_sample_count();   // == fftSize/2
+        const int binCount = (int)frames;
+
+        for (int i = 0; i < bars; ++i) {
+            int lo = _binLo[i];
+            int hi = _binHi[i];
+            if (hi >= binCount) hi = binCount - 1;
+            if (lo > hi) { /* keep previous target of 0 */ }
+
+            // Peak magnitude across the band (peak reads punchier than average).
+            float mag = 0.0f;
+            for (int b = lo; b <= hi; ++b) {
+                float m = 0.0f;
+                for (unsigned c = 0; c < channels; ++c) {
+                    m += (float)std::fabs(data[(size_t)b * channels + c]);
+                }
+                if (channels > 1) m /= (float)channels;
+                if (m > mag) mag = m;
+            }
+
+            float target = magnitudeToDisplay(mag);
+
+            float prev = _bars[i];
+            float keep = (target > prev) ? attackKeep : decayKeep;
+            _bars[i] = prev * keep + target * (1.0f - keep);
+        }
+    } else {
+        // No live audio: decay everything toward zero.
+        for (int i = 0; i < bars; ++i) {
+            _bars[i] *= decayKeep;
+            if (_bars[i] < 0.0015f) _bars[i] = 0.0f;
+        }
+    }
+
+    // Falling peak caps with gravity.
+    bool anyActive = false;
+    for (int i = 0; i < bars; ++i) {
+        if (_bars[i] > _peaks[i]) {
+            _peaks[i] = _bars[i];
+            _peakVel[i] = 0.0f;
+        } else {
+            _peakVel[i] += 0.010f;              // gravity per frame
+            _peaks[i] -= _peakVel[i];
+            if (_peaks[i] < _bars[i]) { _peaks[i] = _bars[i]; _peakVel[i] = 0.0f; }
+            if (_peaks[i] < 0.0f) _peaks[i] = 0.0f;
+        }
+        if (_bars[i] > 0.0f || _peaks[i] > 0.0f) anyActive = true;
+    }
+
+    _active = anyActive;
+    return gotData;
+}
+
+void SpectrumAnalyzer::suspend() {
+    // Called when the view goes off-screen: drop the stream so the core can
+    // stop the visualisation backend. The stream is lazily recreated on the
+    // next tick(). (Do NOT release per-frame while active — a freshly created
+    // stream returns no data for its first reads and would never warm up.)
+    releaseStream();
+    std::fill(_bars.begin(), _bars.end(), 0.0f);
+    std::fill(_peaks.begin(), _peaks.end(), 0.0f);
+    std::fill(_peakVel.begin(), _peakVel.end(), 0.0f);
+    _active = false;
+}

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.cpp
@@ -44,12 +44,16 @@ void SpectrumAnalyzer::configure(const SpectrumAnalyzer::Settings& settings) {
     if (_settings.maxHz <= _settings.minHz + 100) _settings.maxHz = _settings.minHz + 100;
     if (_settings.smoothing < 0)   _settings.smoothing = 0;
     if (_settings.smoothing > 100) _settings.smoothing = 100;
+    if (_settings.shadowFall < 0.0005f) _settings.shadowFall = 0.0005f;
+    if (_settings.peakGravity < 0.00005f) _settings.peakGravity = 0.00005f;
+    if (_settings.peakHoldFrames < 0) _settings.peakHoldFrames = 0;
 
     const size_t n = static_cast<size_t>(_settings.barCount);
     _bars.assign(n, 0.0f);
     _shadow.assign(n, 0.0f);
     _peaks.assign(n, 0.0f);
     _peakVel.assign(n, 0.0f);
+    _peakHold.assign(n, 0);
     _bandsDirty = true;  // bin ranges depend on sample rate, computed lazily
 }
 
@@ -178,28 +182,39 @@ bool SpectrumAnalyzer::tick() {
         }
     }
 
+    // Three timescales, each rising instantly to the bar and falling slower
+    // than the layer beneath it: bar (fast) < shadow (medium) < peak (slowest).
+    const float kShadowFall  = _settings.shadowFall;
+    const int   kPeakHold    = _settings.peakHoldFrames;
+    const float kPeakGravity = _settings.peakGravity;
+
     bool anyActive = false;
     for (int i = 0; i < bars; ++i) {
-        // Slow-decaying shadow fill: jumps up with the bar, eases down slower.
-        if (_bars[i] >= _shadow[i]) {
-            _shadow[i] = _bars[i];
+        const float b = _bars[i];
+
+        // Shadow band: instant rise, steady medium fall.
+        if (b >= _shadow[i]) {
+            _shadow[i] = b;
         } else {
-            _shadow[i] *= 0.90f;
-            if (_shadow[i] < _bars[i]) _shadow[i] = _bars[i];
+            _shadow[i] -= kShadowFall;
+            if (_shadow[i] < b) _shadow[i] = b;
         }
 
-        // Falling peak caps with gravity.
-        if (_bars[i] > _peaks[i]) {
-            _peaks[i] = _bars[i];
+        // Peak line: instant rise, brief hold, then slow accelerating fall.
+        if (b >= _peaks[i]) {
+            _peaks[i] = b;
+            _peakHold[i] = kPeakHold;
             _peakVel[i] = 0.0f;
+        } else if (_peakHold[i] > 0) {
+            _peakHold[i]--;
         } else {
-            _peakVel[i] += 0.010f;              // gravity per frame
+            _peakVel[i] += kPeakGravity;
             _peaks[i] -= _peakVel[i];
-            if (_peaks[i] < _bars[i]) { _peaks[i] = _bars[i]; _peakVel[i] = 0.0f; }
+            if (_peaks[i] < b) { _peaks[i] = b; _peakVel[i] = 0.0f; }
             if (_peaks[i] < 0.0f) _peaks[i] = 0.0f;
         }
 
-        if (_bars[i] > 0.0f || _peaks[i] > 0.0f || _shadow[i] > 0.0f) anyActive = true;
+        if (b > 0.0f || _shadow[i] > 0.0f || _peaks[i] > 0.0f) anyActive = true;
     }
 
     _active = anyActive;
@@ -216,5 +231,6 @@ void SpectrumAnalyzer::suspend() {
     std::fill(_shadow.begin(), _shadow.end(), 0.0f);
     std::fill(_peaks.begin(), _peaks.end(), 0.0f);
     std::fill(_peakVel.begin(), _peakVel.end(), 0.0f);
+    std::fill(_peakHold.begin(), _peakHold.end(), 0);
     _active = false;
 }

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
@@ -1,0 +1,68 @@
+//
+//  SpectrumAnalyzer.h
+//  foo_jl_spectrum_mac
+//
+//  Pulls real-time FFT data from the foobar2000 visualisation stream and maps
+//  it into a fixed number of frequency bars, with temporal smoothing and
+//  falling peak caps. Pure C++ (no Cocoa), driven once per display frame.
+//
+
+#pragma once
+
+#include "../fb2k_sdk.h"
+#include <vector>
+
+class SpectrumAnalyzer {
+public:
+    struct Settings {
+        int    barCount   = 48;
+        int    fftSize    = 4096;    // power of 2
+        int    minHz      = 40;
+        int    maxHz      = 18000;
+        int    smoothing  = 60;      // 0-100, higher = smoother
+        bool   logScale   = true;
+        bool   peakHold    = true;
+    };
+
+    SpectrumAnalyzer();
+
+    // Apply new settings. Rebuilds internal band tables when needed.
+    void configure(const Settings& settings);
+
+    // Pull the latest spectrum and advance smoothing/peak state by one frame.
+    // Safe to call when nothing is playing (bars decay toward zero).
+    // Returns true if live audio data was read, false if idle/decaying.
+    bool tick();
+
+    // Drop the visualisation stream (call when the view goes off-screen).
+    // The stream is lazily recreated on the next tick().
+    void suspend();
+
+    // Current normalized bar magnitudes (0..1), one per bar.
+    const std::vector<float>& bars() const { return _bars; }
+
+    // Current normalized peak-cap positions (0..1), one per bar.
+    const std::vector<float>& peaks() const { return _peaks; }
+
+    // True while any bar or peak is still above zero (view keeps redrawing).
+    bool isActive() const { return _active; }
+
+private:
+    void rebuildBands();
+    void releaseStream();
+
+    Settings _settings;
+    service_ptr_t<visualisation_stream_v2> _stream;
+
+    // Per-bar frequency bin ranges into the FFT magnitude array.
+    std::vector<int> _binLo;   // inclusive
+    std::vector<int> _binHi;   // inclusive
+
+    std::vector<float> _bars;
+    std::vector<float> _peaks;
+    std::vector<float> _peakVel;  // downward velocity per peak cap
+
+    bool _bandsDirty = true;
+    bool _active = false;
+    double _lastSampleRate = 0.0;
+};

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
@@ -41,6 +41,9 @@ public:
     // Current normalized bar magnitudes (0..1), one per bar.
     const std::vector<float>& bars() const { return _bars; }
 
+    // Slow-decaying dim fill behind the bars (0..1) for the "shadow" depth look.
+    const std::vector<float>& shadow() const { return _shadow; }
+
     // Current normalized peak-cap positions (0..1), one per bar.
     const std::vector<float>& peaks() const { return _peaks; }
 
@@ -59,6 +62,7 @@ private:
     std::vector<int> _binHi;   // inclusive
 
     std::vector<float> _bars;
+    std::vector<float> _shadow;   // slow-decaying fill behind bars
     std::vector<float> _peaks;
     std::vector<float> _peakVel;  // downward velocity per peak cap
 

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumAnalyzer.h
@@ -22,6 +22,12 @@ public:
         int    smoothing  = 60;      // 0-100, higher = smoother
         bool   logScale   = true;
         bool   peakHold    = true;
+
+        // Fall dynamics (concrete per-frame rates; the UI maps friendly 0-100
+        // sliders to these). Each layer should fall slower than the one below.
+        float  shadowFall    = 0.012f;   // shadow band linear fall per frame
+        float  peakGravity   = 0.0009f;  // peak line acceleration per frame
+        int    peakHoldFrames = 24;      // frames a peak holds before falling
     };
 
     SpectrumAnalyzer();
@@ -61,10 +67,11 @@ private:
     std::vector<int> _binLo;   // inclusive
     std::vector<int> _binHi;   // inclusive
 
-    std::vector<float> _bars;
-    std::vector<float> _shadow;   // slow-decaying fill behind bars
-    std::vector<float> _peaks;
+    std::vector<float> _bars;     // fast: instantaneous level
+    std::vector<float> _shadow;   // medium: falls slower than the bar
+    std::vector<float> _peaks;    // slowest: holds, then eases down
     std::vector<float> _peakVel;  // downward velocity per peak cap
+    std::vector<int>   _peakHold; // frames remaining before a peak starts falling
 
     bool _bandsDirty = true;
     bool _active = false;

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -31,11 +31,25 @@ enum FreqScale {
     FreqScaleLinear = 1     // Linear
 };
 
+// How the spectrum is drawn
+enum DrawMode {
+    DrawModeBars = 0,       // Discrete frequency bars
+    DrawModeCurve = 1       // Continuous filled curve across all frequencies
+};
+
+// Overall component orientation
+enum Orientation {
+    OrientationHorizontal = 0, // Frequency along X, magnitude grows up
+    OrientationVertical = 1    // Frequency along Y, magnitude grows sideways
+};
+
 // --- Defaults ---
 constexpr int      kDefaultBarCount   = 48;      // Number of frequency bars
 constexpr int      kDefaultFftSize    = 4096;    // FFT window (power of 2)
 constexpr int      kDefaultBarStyle   = BarStyleGradient;
 constexpr int      kDefaultFreqScale  = FreqScaleLog;
+constexpr int      kDefaultDrawMode   = DrawModeBars;
+constexpr int      kDefaultOrientation = OrientationHorizontal;
 constexpr int      kDefaultMinHz      = 20;      // Lowest displayed frequency
 constexpr int      kDefaultMaxHz      = 20000;   // Highest displayed frequency
 constexpr int      kDefaultGapPercent = 20;      // Gap between bars, % of slot width
@@ -70,6 +84,8 @@ static const char* const kKeyBarCount       = "bar_count";
 static const char* const kKeyFftSize        = "fft_size";
 static const char* const kKeyBarStyle       = "bar_style";
 static const char* const kKeyFreqScale      = "freq_scale";
+static const char* const kKeyDrawMode       = "draw_mode";
+static const char* const kKeyOrientation    = "orientation";
 static const char* const kKeyMinHz          = "min_hz";
 static const char* const kKeyMaxHz          = "max_hz";
 static const char* const kKeyGapPercent     = "gap_percent";

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -36,18 +36,20 @@ constexpr int      kDefaultBarCount   = 48;      // Number of frequency bars
 constexpr int      kDefaultFftSize    = 4096;    // FFT window (power of 2)
 constexpr int      kDefaultBarStyle   = BarStyleGradient;
 constexpr int      kDefaultFreqScale  = FreqScaleLog;
-constexpr int      kDefaultMinHz      = 40;      // Lowest displayed frequency
-constexpr int      kDefaultMaxHz      = 18000;   // Highest displayed frequency
+constexpr int      kDefaultMinHz      = 20;      // Lowest displayed frequency
+constexpr int      kDefaultMaxHz      = 20000;   // Highest displayed frequency
 constexpr int      kDefaultGapPercent = 20;      // Gap between bars, % of slot width
 constexpr int      kDefaultSmoothing  = 60;      // Temporal smoothing 0-100 (higher = smoother)
 constexpr bool     kDefaultPeakHold   = true;    // Show falling peak caps
 constexpr bool     kDefaultShowDbGuides = true;  // Show dB scale on the right edge
+constexpr bool     kDefaultShowFreqAxis = true;  // Show frequency labels/gridlines
+constexpr bool     kDefaultShadowFill = true;    // Slow-decaying dim fill behind bars
 constexpr bool     kDefaultGlassBackground = false;
 
 // dB window that maps to the 0..1 bar height. Shared by the analyzer (scaling)
 // and the view (dB guide placement) so the guides line up with the bars.
-constexpr float    kDisplayFloorDb = -70.0f;     // maps to bar height 0
-constexpr float    kDisplayCeilDb  = -6.0f;      // maps to bar height 1
+constexpr float    kDisplayFloorDb = -80.0f;     // maps to bar height 0
+constexpr float    kDisplayCeilDb  = 0.0f;       // maps to bar height 1
 
 // Default colors (ARGB)
 constexpr uint32_t kDefaultBarColorLight = 0xFF2E7DD1;  // Blue
@@ -67,6 +69,8 @@ static const char* const kKeyGapPercent     = "gap_percent";
 static const char* const kKeySmoothing      = "smoothing";
 static const char* const kKeyPeakHold       = "peak_hold";
 static const char* const kKeyShowDbGuides   = "show_db_guides";
+static const char* const kKeyShowFreqAxis   = "show_freq_axis";
+static const char* const kKeyShadowFill     = "shadow_fill";
 static const char* const kKeyGlassBackground = "glass_background";
 static const char* const kKeyBarColorLight  = "bar_color_light";
 static const char* const kKeyBgColorLight   = "bg_color_light";

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -40,6 +40,9 @@ constexpr int      kDefaultMinHz      = 20;      // Lowest displayed frequency
 constexpr int      kDefaultMaxHz      = 20000;   // Highest displayed frequency
 constexpr int      kDefaultGapPercent = 20;      // Gap between bars, % of slot width
 constexpr int      kDefaultSmoothing  = 60;      // Temporal smoothing 0-100 (higher = smoother)
+constexpr int      kDefaultShadowFallSpeed = 40; // Shadow band fall speed 0-100 (higher = faster)
+constexpr int      kDefaultPeakFallSpeed   = 30; // Peak line fall speed 0-100 (higher = faster)
+constexpr int      kDefaultPeakHoldMs      = 400;// Peak line hold time before it starts falling (ms)
 constexpr bool     kDefaultPeakHold   = true;    // Show falling peak caps
 constexpr bool     kDefaultShowDbGuides = true;  // Show dB scale on the right edge
 constexpr bool     kDefaultShowFreqAxis = true;  // Show frequency labels/gridlines
@@ -67,6 +70,9 @@ static const char* const kKeyMinHz          = "min_hz";
 static const char* const kKeyMaxHz          = "max_hz";
 static const char* const kKeyGapPercent     = "gap_percent";
 static const char* const kKeySmoothing      = "smoothing";
+static const char* const kKeyShadowFallSpeed = "shadow_fall_speed";
+static const char* const kKeyPeakFallSpeed   = "peak_fall_speed";
+static const char* const kKeyPeakHoldMs      = "peak_hold_ms";
 static const char* const kKeyPeakHold       = "peak_hold";
 static const char* const kKeyShowDbGuides   = "show_db_guides";
 static const char* const kKeyShowFreqAxis   = "show_freq_axis";

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -47,6 +47,7 @@ constexpr bool     kDefaultPeakHold   = true;    // Show falling peak caps
 constexpr bool     kDefaultShowDbGuides = true;  // Show dB scale on the right edge
 constexpr bool     kDefaultShowFreqAxis = true;  // Show frequency labels/gridlines
 constexpr bool     kDefaultShadowFill = true;    // Slow-decaying dim fill behind bars
+constexpr int      kDefaultGridOpacity = 40;     // Grid line opacity 0-100
 constexpr bool     kDefaultGlassBackground = false;
 
 // dB window that maps to the 0..1 bar height. Shared by the analyzer (scaling)
@@ -59,6 +60,8 @@ constexpr uint32_t kDefaultBarColorLight = 0xFF2E7DD1;  // Blue
 constexpr uint32_t kDefaultBgColorLight  = 0xFFF2F2F2;  // Light gray
 constexpr uint32_t kDefaultBarColorDark  = 0xFF4DA3F0;  // Lighter blue
 constexpr uint32_t kDefaultBgColorDark   = 0xFF161616;  // Near-black
+constexpr uint32_t kDefaultGridColorLight = 0xFF808080; // Neutral gray
+constexpr uint32_t kDefaultGridColorDark  = 0xFF909090; // Neutral gray
 
 // --- Config keys (stored under kConfigPrefix) ---
 static const char* const kConfigPrefix     = "foo_jl_spectrum.";
@@ -77,6 +80,9 @@ static const char* const kKeyPeakHold       = "peak_hold";
 static const char* const kKeyShowDbGuides   = "show_db_guides";
 static const char* const kKeyShowFreqAxis   = "show_freq_axis";
 static const char* const kKeyShadowFill     = "shadow_fill";
+static const char* const kKeyGridOpacity    = "grid_opacity";
+static const char* const kKeyGridColorLight = "grid_color_light";
+static const char* const kKeyGridColorDark  = "grid_color_dark";
 static const char* const kKeyGlassBackground = "glass_background";
 static const char* const kKeyBarColorLight  = "bar_color_light";
 static const char* const kKeyBgColorLight   = "bg_color_light";

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -1,0 +1,112 @@
+//
+//  SpectrumConfig.h
+//  foo_jl_spectrum_mac
+//
+//  Configuration GUIDs, enums, defaults, and fb2k::configStore accessors.
+//  Config is persisted via fb2k::configStore (cfg_var does not persist on macOS v2).
+//
+
+#pragma once
+
+#include "../fb2k_sdk.h"
+
+namespace spectrum_config {
+
+// Preferences page GUID (shared by page registration and "open preferences" actions)
+static const GUID guid_preferences_page = {
+    0x2F9A7C41, 0x8B3D, 0x4E62,
+    {0xA1, 0x05, 0x9D, 0x77, 0x3C, 0x18, 0x6E, 0x2A}
+};
+
+// Bar fill styles
+enum BarStyle {
+    BarStyleSolid = 0,      // Single color
+    BarStyleGradient = 1,   // Vertical gradient (bottom -> top)
+    BarStyleSpectrum = 2    // Hue mapped across frequency (low -> high)
+};
+
+// Frequency axis mapping
+enum FreqScale {
+    FreqScaleLog = 0,       // Logarithmic (musically natural)
+    FreqScaleLinear = 1     // Linear
+};
+
+// --- Defaults ---
+constexpr int      kDefaultBarCount   = 48;      // Number of frequency bars
+constexpr int      kDefaultFftSize    = 4096;    // FFT window (power of 2)
+constexpr int      kDefaultBarStyle   = BarStyleGradient;
+constexpr int      kDefaultFreqScale  = FreqScaleLog;
+constexpr int      kDefaultMinHz      = 40;      // Lowest displayed frequency
+constexpr int      kDefaultMaxHz      = 18000;   // Highest displayed frequency
+constexpr int      kDefaultGapPercent = 20;      // Gap between bars, % of slot width
+constexpr int      kDefaultSmoothing  = 60;      // Temporal smoothing 0-100 (higher = smoother)
+constexpr bool     kDefaultPeakHold   = true;    // Show falling peak caps
+constexpr bool     kDefaultShowDbGuides = true;  // Show dB scale on the right edge
+constexpr bool     kDefaultGlassBackground = false;
+
+// dB window that maps to the 0..1 bar height. Shared by the analyzer (scaling)
+// and the view (dB guide placement) so the guides line up with the bars.
+constexpr float    kDisplayFloorDb = -70.0f;     // maps to bar height 0
+constexpr float    kDisplayCeilDb  = -6.0f;      // maps to bar height 1
+
+// Default colors (ARGB)
+constexpr uint32_t kDefaultBarColorLight = 0xFF2E7DD1;  // Blue
+constexpr uint32_t kDefaultBgColorLight  = 0xFFF2F2F2;  // Light gray
+constexpr uint32_t kDefaultBarColorDark  = 0xFF4DA3F0;  // Lighter blue
+constexpr uint32_t kDefaultBgColorDark   = 0xFF161616;  // Near-black
+
+// --- Config keys (stored under kConfigPrefix) ---
+static const char* const kConfigPrefix     = "foo_jl_spectrum.";
+static const char* const kKeyBarCount       = "bar_count";
+static const char* const kKeyFftSize        = "fft_size";
+static const char* const kKeyBarStyle       = "bar_style";
+static const char* const kKeyFreqScale      = "freq_scale";
+static const char* const kKeyMinHz          = "min_hz";
+static const char* const kKeyMaxHz          = "max_hz";
+static const char* const kKeyGapPercent     = "gap_percent";
+static const char* const kKeySmoothing      = "smoothing";
+static const char* const kKeyPeakHold       = "peak_hold";
+static const char* const kKeyShowDbGuides   = "show_db_guides";
+static const char* const kKeyGlassBackground = "glass_background";
+static const char* const kKeyBarColorLight  = "bar_color_light";
+static const char* const kKeyBgColorLight   = "bg_color_light";
+static const char* const kKeyBarColorDark   = "bar_color_dark";
+static const char* const kKeyBgColorDark    = "bg_color_dark";
+
+// Notification posted when preferences change so live views can reload.
+// Guarded so this header stays includable from pure C++ translation units.
+#ifdef __OBJC__
+static NSString* const kSettingsChangedNotification = @"SpectrumAnalyzerSettingsChanged";
+#endif
+
+// --- configStore accessors ---
+inline int64_t getConfigInt(const char* key, int64_t defaultVal) {
+    try {
+        auto store = fb2k::configStore::get();
+        pfc::string8 fullKey;
+        fullKey << kConfigPrefix << key;
+        return store->getConfigInt(fullKey.c_str(), defaultVal);
+    } catch (...) {
+        return defaultVal;
+    }
+}
+
+inline void setConfigInt(const char* key, int64_t value) {
+    try {
+        auto store = fb2k::configStore::get();
+        pfc::string8 fullKey;
+        fullKey << kConfigPrefix << key;
+        store->setConfigInt(fullKey.c_str(), value);
+    } catch (...) {
+    }
+}
+
+inline bool getConfigBool(const char* key, bool defaultVal) {
+    return getConfigInt(key, defaultVal ? 1 : 0) != 0;
+}
+
+inline void setConfigBool(const char* key, bool value) {
+    setConfigInt(key, value ? 1 : 0);
+}
+
+} // namespace spectrum_config

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumConfig.h
@@ -48,6 +48,7 @@ constexpr bool     kDefaultShowDbGuides = true;  // Show dB scale on the right e
 constexpr bool     kDefaultShowFreqAxis = true;  // Show frequency labels/gridlines
 constexpr bool     kDefaultShadowFill = true;    // Slow-decaying dim fill behind bars
 constexpr int      kDefaultGridOpacity = 40;     // Grid line opacity 0-100
+constexpr int      kDefaultTheme = 1;            // Color preset index (0 = Custom, 1 = Default)
 constexpr bool     kDefaultGlassBackground = false;
 
 // dB window that maps to the 0..1 bar height. Shared by the analyzer (scaling)
@@ -83,6 +84,7 @@ static const char* const kKeyShadowFill     = "shadow_fill";
 static const char* const kKeyGridOpacity    = "grid_opacity";
 static const char* const kKeyGridColorLight = "grid_color_light";
 static const char* const kKeyGridColorDark  = "grid_color_dark";
+static const char* const kKeyTheme          = "color_theme";
 static const char* const kKeyGlassBackground = "glass_background";
 static const char* const kKeyBarColorLight  = "bar_color_light";
 static const char* const kKeyBgColorLight   = "bg_color_light";

--- a/extensions/foo_jl_spectrum_mac/src/Core/SpectrumThemes.h
+++ b/extensions/foo_jl_spectrum_mac/src/Core/SpectrumThemes.h
@@ -1,0 +1,73 @@
+//
+//  SpectrumThemes.h
+//  foo_jl_spectrum_mac
+//
+//  Curated color presets (MiniMeters-style). A theme stamps the bar,
+//  background, and grid colors for both light and dark appearance at once.
+//  Index 0 is "Custom" (applying it is a no-op); real presets start at 1.
+//
+
+#pragma once
+
+#include "SpectrumConfig.h"
+
+namespace spectrum_config {
+
+struct Theme {
+    const char* name;
+    uint32_t barLight,  bgLight,  gridLight;
+    uint32_t barDark,   bgDark,   gridDark;
+};
+
+// ARGB (0xAARRGGBB). Light variants adapt each palette to a light background.
+static const Theme kThemes[] = {
+    // 0: Custom sentinel — values mirror Default but are never applied.
+    { "Custom",
+      0xFF2E7DD1, 0xFFF2F2F2, 0xFF808080,   0xFF4DA3F0, 0xFF161616, 0xFF909090 },
+
+    { "Default (Blue)",
+      0xFF2E7DD1, 0xFFF2F2F2, 0xFF808080,   0xFF4DA3F0, 0xFF161616, 0xFF909090 },
+
+    { "Classic (Green)",
+      0xFF1B8A3A, 0xFFF4F4F4, 0xFF9AA0A0,   0xFF33FF66, 0xFF0A0A0A, 0xFF4D4D4D },
+
+    { "Nord",
+      0xFF5E81AC, 0xFFECEFF4, 0xFFB0B6C0,   0xFF88C0D0, 0xFF2E3440, 0xFF4C566A },
+
+    { "Dracula",
+      0xFF8B5CF6, 0xFFF8F8F2, 0xFFCFCFD6,   0xFFBD93F9, 0xFF282A36, 0xFF44475A },
+
+    { "Gruvbox",
+      0xFFD65D0E, 0xFFFBF1C7, 0xFFBDB4A0,   0xFFFE8019, 0xFF282828, 0xFF504945 },
+
+    { "Solarized",
+      0xFF268BD2, 0xFFFDF6E3, 0xFF93A1A1,   0xFF268BD2, 0xFF002B36, 0xFF586E75 },
+
+    { "Tokyo Night",
+      0xFF3D59A1, 0xFFD5D6DB, 0xFFA8AECB,   0xFF7AA2F7, 0xFF1A1B26, 0xFF414868 },
+
+    { "Catppuccin",
+      0xFF8839EF, 0xFFEFF1F5, 0xFFBCC0CC,   0xFFCBA6F7, 0xFF1E1E2E, 0xFF45475A },
+
+    { "Monokai",
+      0xFF4E9A06, 0xFFF8F8F2, 0xFFC8C8B8,   0xFFA6E22E, 0xFF272822, 0xFF49483E },
+
+    { "Sunset",
+      0xFFE8551A, 0xFFFFF3EC, 0xFFD8B8A0,   0xFFFF6B35, 0xFF1A0F0A, 0xFF4D3326 },
+};
+
+static const int kThemeCount = (int)(sizeof(kThemes) / sizeof(kThemes[0]));
+
+// Write a preset's colors into config. No-op for index 0 (Custom) or invalid.
+inline void applyThemeToConfig(int index) {
+    if (index <= 0 || index >= kThemeCount) return;
+    const Theme& t = kThemes[index];
+    setConfigInt(kKeyBarColorLight,  t.barLight);
+    setConfigInt(kKeyBgColorLight,   t.bgLight);
+    setConfigInt(kKeyGridColorLight, t.gridLight);
+    setConfigInt(kKeyBarColorDark,   t.barDark);
+    setConfigInt(kKeyBgColorDark,    t.bgDark);
+    setConfigInt(kKeyGridColorDark,  t.gridDark);
+}
+
+} // namespace spectrum_config

--- a/extensions/foo_jl_spectrum_mac/src/Integration/Main.mm
+++ b/extensions/foo_jl_spectrum_mac/src/Integration/Main.mm
@@ -1,0 +1,64 @@
+//
+//  Main.mm
+//  foo_jl_spectrum_mac
+//
+//  Component registration and SDK integration.
+//
+
+#include "../fb2k_sdk.h"
+#include "../../../../shared/common_about.h"
+#include "../../../../shared/version.h"
+
+#import "../UI/SpectrumController.h"
+
+JL_COMPONENT_ABOUT(
+    "Spectrum Analyzer",
+    SPECTRUM_VERSION,
+    "Real-time spectrum analyzer for foobar2000 macOS\n\n"
+    "Features:\n"
+    "- Live FFT frequency bars from the playback stream\n"
+    "- Logarithmic or linear frequency scale\n"
+    "- Adjustable bar count, FFT size, and smoothing\n"
+    "- Falling peak caps\n"
+    "- Solid / gradient / spectrum bar styles\n"
+    "- Light and dark mode colors\n"
+    "- Glass background (translucent blur)"
+);
+
+VALIDATE_COMPONENT_FILENAME("foo_jl_spectrum.component");
+
+// UI Element service registration (embeddable view)
+namespace {
+    static const GUID g_guid_spectrum_ui_element = {
+        0x6E1B4A83, 0x2C9F, 0x4D51,
+        {0xB7, 0x3A, 0x0F, 0x82, 0x64, 0x11, 0x9C, 0xE0}
+    };
+
+    class spectrum_ui_element : public ui_element_mac {
+    public:
+        service_ptr instantiate(service_ptr arg) override {
+            @autoreleasepool {
+                SpectrumController* controller = [[SpectrumController alloc] init];
+                return fb2k::wrapNSObject(controller);
+            }
+        }
+
+        bool match_name(const char* name) override {
+            return strcmp(name, "Spectrum Analyzer") == 0 ||
+                   strcmp(name, "spectrum_analyzer") == 0 ||
+                   strcmp(name, "spectrum") == 0 ||
+                   strcmp(name, "foo_jl_spectrum") == 0 ||
+                   strcmp(name, "jl_spectrum") == 0;
+        }
+
+        fb2k::stringRef get_name() override {
+            return fb2k::makeString("Spectrum Analyzer");
+        }
+
+        GUID get_guid() override {
+            return g_guid_spectrum_ui_element;
+        }
+    };
+
+    FB2K_SERVICE_FACTORY(spectrum_ui_element);
+}

--- a/extensions/foo_jl_spectrum_mac/src/Prefix.pch
+++ b/extensions/foo_jl_spectrum_mac/src/Prefix.pch
@@ -1,0 +1,30 @@
+//
+//  Prefix.pch
+//  foo_jl_spectrum_mac
+//
+//  Precompiled header for macOS build
+//
+
+#pragma once
+
+// Enable legacy cfg_var API for compatibility with Windows code
+#define FOOBAR2000_HAVE_CFG_VAR_LEGACY 1
+
+// foobar2000 SDK
+#include <foobar2000/SDK/foobar2000.h>
+
+// Standard library
+#include <string>
+#include <vector>
+#include <cmath>
+#include <memory>
+#include <atomic>
+#include <algorithm>
+#include <cstdint>
+
+// macOS/Cocoa (when included from .mm files)
+#ifdef __OBJC__
+#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+#endif

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.h
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.h
@@ -1,0 +1,21 @@
+//
+//  SpectrumController.h
+//  foo_jl_spectrum_mac
+//
+//  NSViewController hosting the spectrum view; drives the display timer.
+//
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+#import "SpectrumView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SpectrumController : NSViewController <SpectrumViewDelegate>
+
+@property (nonatomic, readonly) SpectrumView *spectrumView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
@@ -150,8 +150,10 @@
         // Redraw while there is live audio or bars/peaks are still settling.
         if (live || _analyzer->isActive()) {
             const auto &bars = _analyzer->bars();
+            const auto &shadow = _analyzer->shadow();
             const auto &peaks = _analyzer->peaks();
             [self.spectrumView setBarsData:bars.data()
+                                    shadow:shadow.data()
                                      peaks:peaks.data()
                                      count:(NSInteger)bars.size()];
         }

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
@@ -1,0 +1,184 @@
+//
+//  SpectrumController.mm
+//  foo_jl_spectrum_mac
+//
+
+#import "SpectrumController.h"
+#include "../Core/SpectrumAnalyzer.h"
+#include "../Core/SpectrumConfig.h"
+#include <memory>
+
+@interface SpectrumController () {
+    std::unique_ptr<SpectrumAnalyzer> _analyzer;
+    NSTimer *_timer;
+    NSVisualEffectView *_glassEffectView;
+}
+@property (nonatomic, readwrite) SpectrumView *spectrumView;
+@end
+
+@implementation SpectrumController
+
+- (instancetype)init {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _analyzer = std::make_unique<SpectrumAnalyzer>();
+    }
+    return self;
+}
+
+- (void)loadView {
+    NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 400, 120)];
+    container.wantsLayer = YES;
+    container.layer.cornerRadius = 6.0;
+    container.layer.masksToBounds = YES;
+
+    SpectrumView *view = [[SpectrumView alloc] initWithFrame:container.bounds];
+    view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    view.delegate = self;
+    self.spectrumView = view;
+
+    [container addSubview:view];
+    self.view = container;
+
+    [self updateGlassBackground];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [NSLayoutConstraint activateConstraints:@[
+        [self.view.widthAnchor constraintGreaterThanOrEqualToConstant:80],
+        [self.view.heightAnchor constraintGreaterThanOrEqualToConstant:40]
+    ]];
+
+    [self applySettings];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleSettingsChanged:)
+                                                 name:spectrum_config::kSettingsChangedNotification
+                                               object:nil];
+
+    // Start now as well: appearance callbacks are not guaranteed for a view
+    // hosted inside the foobar2000 layout. tick guards on window visibility.
+    [self startTimer];
+}
+
+- (void)viewDidAppear {
+    [super viewDidAppear];
+    [self startTimer];
+}
+
+- (void)viewDidDisappear {
+    [super viewDidDisappear];
+    [self stopTimer];
+    _analyzer->suspend();
+}
+
+- (void)dealloc {
+    [self stopTimer];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - Settings
+
+- (void)applySettings {
+    using namespace spectrum_config;
+    SpectrumAnalyzer::Settings s;
+    s.barCount  = (int)getConfigInt(kKeyBarCount, kDefaultBarCount);
+    s.fftSize   = (int)getConfigInt(kKeyFftSize, kDefaultFftSize);
+    s.minHz     = (int)getConfigInt(kKeyMinHz, kDefaultMinHz);
+    s.maxHz     = (int)getConfigInt(kKeyMaxHz, kDefaultMaxHz);
+    s.smoothing = (int)getConfigInt(kKeySmoothing, kDefaultSmoothing);
+    s.logScale  = getConfigInt(kKeyFreqScale, kDefaultFreqScale) == FreqScaleLog;
+    s.peakHold  = getConfigBool(kKeyPeakHold, kDefaultPeakHold);
+    _analyzer->configure(s);
+
+    [self.spectrumView reloadSettings];
+    [self updateGlassBackground];
+}
+
+- (void)handleSettingsChanged:(NSNotification *)note {
+    [self applySettings];
+}
+
+- (void)updateGlassBackground {
+    using namespace spectrum_config;
+    BOOL glass = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground);
+    if (glass == (_glassEffectView != nil)) return;
+
+    if (glass) {
+        _glassEffectView = [[NSVisualEffectView alloc] initWithFrame:self.view.bounds];
+        _glassEffectView.material = NSVisualEffectMaterialSidebar;
+        _glassEffectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+        _glassEffectView.state = NSVisualEffectStateActive;
+        _glassEffectView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        [self.view addSubview:_glassEffectView positioned:NSWindowBelow relativeTo:self.spectrumView];
+    } else {
+        [_glassEffectView removeFromSuperview];
+        _glassEffectView = nil;
+    }
+}
+
+#pragma mark - Timer
+
+- (void)startTimer {
+    [self stopTimer];
+    __weak typeof(self) weakSelf = self;
+    _timer = [NSTimer scheduledTimerWithTimeInterval:1.0 / 60.0
+                                             repeats:YES
+                                               block:^(NSTimer *t) {
+        __strong typeof(weakSelf) self = weakSelf;
+        if (!self) { [t invalidate]; return; }
+        [self tick];
+    }];
+    [[NSRunLoop currentRunLoop] addTimer:_timer forMode:NSRunLoopCommonModes];
+}
+
+- (void)stopTimer {
+    [_timer invalidate];
+    _timer = nil;
+}
+
+- (void)tick {
+    @autoreleasepool {
+        if (!self.view.window || self.view.isHiddenOrHasHiddenAncestor) return;
+
+        bool live = _analyzer->tick();
+        self.spectrumView.playing = live;
+
+        // Redraw while there is live audio or bars/peaks are still settling.
+        if (live || _analyzer->isActive()) {
+            const auto &bars = _analyzer->bars();
+            const auto &peaks = _analyzer->peaks();
+            [self.spectrumView setBarsData:bars.data()
+                                     peaks:peaks.data()
+                                     count:(NSInteger)bars.size()];
+        }
+    }
+}
+
+#pragma mark - SpectrumViewDelegate
+
+- (void)spectrumViewRequestsContextMenu:(SpectrumView *)view atPoint:(NSPoint)point {
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Spectrum Analyzer"];
+    NSMenuItem *prefs = [[NSMenuItem alloc] initWithTitle:@"Preferences..."
+                                                   action:@selector(menuShowPreferences:)
+                                            keyEquivalent:@""];
+    prefs.target = self;
+    [menu addItem:prefs];
+    [menu popUpMenuPositioningItem:nil atLocation:point inView:view];
+}
+
+- (void)menuShowPreferences:(NSMenuItem *)sender {
+    @try {
+        auto uiControl = ui_control::get();
+        if (uiControl.is_valid()) {
+            uiControl->show_preferences(spectrum_config::guid_preferences_page);
+        }
+    } @catch (...) {
+        console::error("[Spectrum] Failed to open preferences");
+    }
+}
+
+@end

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
@@ -92,6 +92,15 @@
     s.smoothing = (int)getConfigInt(kKeySmoothing, kDefaultSmoothing);
     s.logScale  = getConfigInt(kKeyFreqScale, kDefaultFreqScale) == FreqScaleLog;
     s.peakHold  = getConfigBool(kKeyPeakHold, kDefaultPeakHold);
+
+    // Map friendly 0-100 sliders / ms to concrete per-frame rates (60fps timer).
+    double shadowSpeed = getConfigInt(kKeyShadowFallSpeed, kDefaultShadowFallSpeed) / 100.0;
+    double peakSpeed   = getConfigInt(kKeyPeakFallSpeed, kDefaultPeakFallSpeed) / 100.0;
+    int    peakHoldMs  = (int)getConfigInt(kKeyPeakHoldMs, kDefaultPeakHoldMs);
+    s.shadowFall     = (float)(0.001 + shadowSpeed * 0.0275);   // ~0.001 (slow) .. 0.0285 (fast)
+    s.peakGravity    = (float)(0.0001 + peakSpeed * 0.0027);    // ~0.0001 .. 0.0028
+    s.peakHoldFrames = (int)std::lround(peakHoldMs * 60.0 / 1000.0);
+
     _analyzer->configure(s);
 
     [self.spectrumView reloadSettings];

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumController.mm
@@ -7,6 +7,10 @@
 #include "../Core/SpectrumAnalyzer.h"
 #include "../Core/SpectrumConfig.h"
 #include <memory>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <algorithm>
 
 @interface SpectrumController () {
     std::unique_ptr<SpectrumAnalyzer> _analyzer;
@@ -14,7 +18,42 @@
     NSVisualEffectView *_glassEffectView;
 }
 @property (nonatomic, readwrite) SpectrumView *spectrumView;
+- (void)shutdownForQuit;
 @end
+
+// Registry of live controllers so we can release visualisation streams before
+// the core tears down the vis backend at quit. Holding an open stream during
+// component shutdown triggers exception_service_not_found.
+namespace {
+    std::mutex g_controllersMutex;
+    std::vector<__weak SpectrumController*> g_controllers;
+    std::atomic<bool> g_shutdown{false};
+
+    void registerController(SpectrumController* c) {
+        std::lock_guard<std::mutex> lock(g_controllersMutex);
+        g_controllers.push_back(c);
+    }
+    void unregisterController(SpectrumController* c) {
+        std::lock_guard<std::mutex> lock(g_controllersMutex);
+        g_controllers.erase(std::remove_if(g_controllers.begin(), g_controllers.end(),
+            [c](__weak SpectrumController* w){ return w == nil || w == c; }),
+            g_controllers.end());
+    }
+}
+
+// Release streams and stop timers before the service system shuts down.
+class spectrum_initquit : public initquit {
+public:
+    void on_quit() override {
+        g_shutdown.store(true);
+        std::lock_guard<std::mutex> lock(g_controllersMutex);
+        for (__weak SpectrumController* w : g_controllers) {
+            SpectrumController* c = w;
+            if (c) [c shutdownForQuit];
+        }
+    }
+};
+FB2K_SERVICE_FACTORY(spectrum_initquit);
 
 @implementation SpectrumController
 
@@ -59,6 +98,8 @@
                                                  name:spectrum_config::kSettingsChangedNotification
                                                object:nil];
 
+    registerController(self);
+
     // Start now as well: appearance callbacks are not guaranteed for a view
     // hosted inside the foobar2000 layout. tick guards on window visibility.
     [self startTimer];
@@ -75,8 +116,14 @@
     _analyzer->suspend();
 }
 
+- (void)shutdownForQuit {
+    [self stopTimer];
+    if (_analyzer) _analyzer->suspend();
+}
+
 - (void)dealloc {
     [self stopTimer];
+    unregisterController(self);
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -133,6 +180,7 @@
 
 - (void)startTimer {
     [self stopTimer];
+    if (g_shutdown.load()) return;
     __weak typeof(self) weakSelf = self;
     _timer = [NSTimer scheduledTimerWithTimeInterval:1.0 / 60.0
                                              repeats:YES
@@ -151,6 +199,7 @@
 
 - (void)tick {
     @autoreleasepool {
+        if (g_shutdown.load()) { [self stopTimer]; return; }
         if (!self.view.window || self.view.isHiddenOrHasHiddenAncestor) return;
 
         bool live = _analyzer->tick();

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.h
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.h
@@ -1,0 +1,18 @@
+//
+//  SpectrumPreferences.h
+//  foo_jl_spectrum_mac
+//
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SpectrumPreferences : NSViewController
+
+@property (nonatomic, readonly) NSString *preferencesTitle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -27,7 +27,9 @@
     NSSlider      *_smoothingSlider;
     NSTextField   *_smoothingLabel;
     NSButton      *_peakHoldCheckbox;
+    NSButton      *_shadowFillCheckbox;
     NSButton      *_dbGuidesCheckbox;
+    NSButton      *_freqAxisCheckbox;
     NSButton      *_glassCheckbox;
     NSColorWell   *_barColorLightWell;
     NSColorWell   *_bgColorLightWell;
@@ -45,7 +47,7 @@
 - (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
 
 - (void)loadView {
-    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 500)];
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 560)];
     self.view = view;
     [NSColor setIgnoresAlpha:NO];
     [NSColorPanel sharedColorPanel].showsAlpha = YES;
@@ -71,7 +73,7 @@
 
     [self.view addSubview:[self label:@"Bars:" at:NSMakePoint(labelX + 10, y + 3)]];
     _barCountPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 100, 25)];
-    for (NSNumber *n in @[@16, @24, @32, @48, @64, @96, @128]) {
+    for (NSNumber *n in @[@16, @24, @32, @48, @64, @96, @128, @192, @256]) {
         [_barCountPopup addItemWithTitle:n.stringValue];
     }
     _barCountPopup.target = self; _barCountPopup.action = @selector(barCountChanged:);
@@ -144,9 +146,19 @@
     [self.view addSubview:_peakHoldCheckbox];
     y += 26;
 
+    _shadowFillCheckbox = [self checkbox:@"Shadow fill" at:NSMakePoint(labelX + 10, y)];
+    _shadowFillCheckbox.toolTip = @"Dim, slow-decaying fill behind bars for depth";
+    [self.view addSubview:_shadowFillCheckbox];
+    y += 26;
+
     _dbGuidesCheckbox = [self checkbox:@"Show dB scale" at:NSMakePoint(labelX + 10, y)];
     _dbGuidesCheckbox.toolTip = @"Draw decibel guide lines and labels on the right edge";
     [self.view addSubview:_dbGuidesCheckbox];
+    y += 26;
+
+    _freqAxisCheckbox = [self checkbox:@"Show frequency axis" at:NSMakePoint(labelX + 10, y)];
+    _freqAxisCheckbox.toolTip = @"Draw frequency gridlines and labels along the bottom";
+    [self.view addSubview:_freqAxisCheckbox];
     y += 26;
 
     _glassCheckbox = [self checkbox:@"Glass background" at:NSMakePoint(labelX + 10, y)];
@@ -240,7 +252,9 @@
     _gapLabel.stringValue = [NSString stringWithFormat:@"%d%%", gap];
 
     _peakHoldCheckbox.state = getConfigBool(kKeyPeakHold, kDefaultPeakHold) ? NSControlStateValueOn : NSControlStateValueOff;
+    _shadowFillCheckbox.state = getConfigBool(kKeyShadowFill, kDefaultShadowFill) ? NSControlStateValueOn : NSControlStateValueOff;
     _dbGuidesCheckbox.state = getConfigBool(kKeyShowDbGuides, kDefaultShowDbGuides) ? NSControlStateValueOn : NSControlStateValueOff;
+    _freqAxisCheckbox.state = getConfigBool(kKeyShowFreqAxis, kDefaultShowFreqAxis) ? NSControlStateValueOn : NSControlStateValueOff;
     _glassCheckbox.state = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground) ? NSControlStateValueOn : NSControlStateValueOff;
 
     _barColorLightWell.color = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight)];
@@ -325,8 +339,12 @@
     using namespace spectrum_config;
     if (sender == _peakHoldCheckbox) {
         setConfigBool(kKeyPeakHold, _peakHoldCheckbox.state == NSControlStateValueOn);
+    } else if (sender == _shadowFillCheckbox) {
+        setConfigBool(kKeyShadowFill, _shadowFillCheckbox.state == NSControlStateValueOn);
     } else if (sender == _dbGuidesCheckbox) {
         setConfigBool(kKeyShowDbGuides, _dbGuidesCheckbox.state == NSControlStateValueOn);
+    } else if (sender == _freqAxisCheckbox) {
+        setConfigBool(kKeyShowFreqAxis, _freqAxisCheckbox.state == NSControlStateValueOn);
     } else if (sender == _glassCheckbox) {
         setConfigBool(kKeyGlassBackground, _glassCheckbox.state == NSControlStateValueOn);
     }

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -41,6 +41,10 @@
     NSColorWell   *_bgColorLightWell;
     NSColorWell   *_barColorDarkWell;
     NSColorWell   *_bgColorDarkWell;
+    NSSlider      *_gridOpacitySlider;
+    NSTextField   *_gridOpacityLabel;
+    NSColorWell   *_gridColorLightWell;
+    NSColorWell   *_gridColorDarkWell;
 }
 @end
 
@@ -53,7 +57,7 @@
 - (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
 
 - (void)loadView {
-    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 690)];
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 780)];
     self.view = view;
     [NSColor setIgnoresAlpha:NO];
     [NSColorPanel sharedColorPanel].showsAlpha = YES;
@@ -229,6 +233,29 @@
     _bgColorDarkWell = [self colorWellAt:NSMakePoint(controlX + 150, y)];
     [self.view addSubview:_bgColorDarkWell];
     y += 32;
+
+    // --- Grid section (dB scale + frequency axis) ---
+    NSTextField *gridHeader = JLCreateSectionHeader(@"Grid (dB scale & frequency axis)");
+    gridHeader.frame = NSMakeRect(labelX, y, 300, 17);
+    [self.view addSubview:gridHeader];
+    y += 22;
+
+    [self.view addSubview:[self label:@"Opacity:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _gridOpacitySlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _gridOpacitySlider.minValue = 0; _gridOpacitySlider.maxValue = 100; _gridOpacitySlider.continuous = YES;
+    _gridOpacitySlider.target = self; _gridOpacitySlider.action = @selector(gridOpacityChanged:);
+    [self.view addSubview:_gridOpacitySlider];
+    _gridOpacityLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_gridOpacityLabel];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Color (light):" at:NSMakePoint(labelX + 10, y + 3)]];
+    _gridColorLightWell = [self colorWellAt:NSMakePoint(controlX, y)];
+    [self.view addSubview:_gridColorLightWell];
+    [self.view addSubview:[self label:@"Color (dark):" at:NSMakePoint(controlX + 60, y + 3)]];
+    _gridColorDarkWell = [self colorWellAt:NSMakePoint(controlX + 150, y)];
+    [self.view addSubview:_gridColorDarkWell];
+    y += 32;
 }
 
 #pragma mark - Control factory helpers
@@ -315,6 +342,12 @@
     _bgColorLightWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight)];
     _barColorDarkWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorDark, kDefaultBarColorDark)];
     _bgColorDarkWell.color   = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorDark, kDefaultBgColorDark)];
+
+    int gridOpacity = (int)getConfigInt(kKeyGridOpacity, kDefaultGridOpacity);
+    _gridOpacitySlider.integerValue = gridOpacity;
+    _gridOpacityLabel.stringValue = [NSString stringWithFormat:@"%d%%", gridOpacity];
+    _gridColorLightWell.color = [self colorFromARGB:(uint32_t)getConfigInt(kKeyGridColorLight, kDefaultGridColorLight)];
+    _gridColorDarkWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyGridColorDark, kDefaultGridColorDark)];
 }
 
 - (void)selectPopup:(NSPopUpButton *)popup value:(int)value {
@@ -426,12 +459,21 @@
     [self notifyChanged];
 }
 
+- (void)gridOpacityChanged:(id)sender {
+    int v = (int)_gridOpacitySlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeyGridOpacity, v);
+    _gridOpacityLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
 - (void)colorChanged:(id)sender {
     using namespace spectrum_config;
     if (sender == _barColorLightWell)      setConfigInt(kKeyBarColorLight, [self argbFromColor:_barColorLightWell.color]);
     else if (sender == _bgColorLightWell)  setConfigInt(kKeyBgColorLight, [self argbFromColor:_bgColorLightWell.color]);
     else if (sender == _barColorDarkWell)  setConfigInt(kKeyBarColorDark, [self argbFromColor:_barColorDarkWell.color]);
     else if (sender == _bgColorDarkWell)   setConfigInt(kKeyBgColorDark, [self argbFromColor:_bgColorDarkWell.color]);
+    else if (sender == _gridColorLightWell) setConfigInt(kKeyGridColorLight, [self argbFromColor:_gridColorLightWell.color]);
+    else if (sender == _gridColorDarkWell)  setConfigInt(kKeyGridColorDark, [self argbFromColor:_gridColorDarkWell.color]);
     [self notifyChanged];
 }
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -18,6 +18,8 @@
 
 @interface SpectrumPreferences () {
     NSPopUpButton *_themePopup;
+    NSPopUpButton *_drawModePopup;
+    NSPopUpButton *_orientationPopup;
     NSPopUpButton *_barCountPopup;
     NSPopUpButton *_fftSizePopup;
     NSPopUpButton *_barStylePopup;
@@ -59,7 +61,7 @@
 - (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
 
 - (void)loadView {
-    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 810)];
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 870)];
     self.view = view;
     [NSColor setIgnoresAlpha:NO];
     [NSColorPanel sharedColorPanel].showsAlpha = YES;
@@ -180,6 +182,22 @@
     _themePopup.target = self; _themePopup.action = @selector(themeChanged:);
     _themePopup.toolTip = @"Apply a color preset to bars, background, and grid";
     [self.view addSubview:_themePopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Draw mode:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _drawModePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 130, 25)];
+    [_drawModePopup addItemWithTitle:@"Bars"];
+    [_drawModePopup addItemWithTitle:@"Curve"];
+    _drawModePopup.target = self; _drawModePopup.action = @selector(drawModeChanged:);
+    [self.view addSubview:_drawModePopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Orientation:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _orientationPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 130, 25)];
+    [_orientationPopup addItemWithTitle:@"Horizontal"];
+    [_orientationPopup addItemWithTitle:@"Vertical"];
+    _orientationPopup.target = self; _orientationPopup.action = @selector(orientationChanged:);
+    [self.view addSubview:_orientationPopup];
     y += 30;
 
     [self.view addSubview:[self label:@"Bar style:" at:NSMakePoint(labelX + 10, y + 3)]];
@@ -320,6 +338,8 @@
     [self selectPopup:_fftSizePopup value:(int)getConfigInt(kKeyFftSize, kDefaultFftSize)];
     [_freqScalePopup selectItemAtIndex:getConfigInt(kKeyFreqScale, kDefaultFreqScale)];
     [_barStylePopup selectItemAtIndex:getConfigInt(kKeyBarStyle, kDefaultBarStyle)];
+    [_drawModePopup selectItemAtIndex:getConfigInt(kKeyDrawMode, kDefaultDrawMode)];
+    [_orientationPopup selectItemAtIndex:getConfigInt(kKeyOrientation, kDefaultOrientation)];
 
     _minHzField.integerValue = getConfigInt(kKeyMinHz, kDefaultMinHz);
     _maxHzField.integerValue = getConfigInt(kKeyMaxHz, kDefaultMaxHz);
@@ -416,6 +436,16 @@
 
 - (void)barStyleChanged:(id)sender {
     spectrum_config::setConfigInt(spectrum_config::kKeyBarStyle, _barStylePopup.indexOfSelectedItem);
+    [self notifyChanged];
+}
+
+- (void)drawModeChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyDrawMode, _drawModePopup.indexOfSelectedItem);
+    [self notifyChanged];
+}
+
+- (void)orientationChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyOrientation, _orientationPopup.indexOfSelectedItem);
     [self notifyChanged];
 }
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -6,6 +6,7 @@
 #import "SpectrumPreferences.h"
 #include "../fb2k_sdk.h"
 #include "../Core/SpectrumConfig.h"
+#include "../Core/SpectrumThemes.h"
 #import "../../../../shared/PreferencesCommon.h"
 
 // Uniquely-named flipped view (avoids ObjC runtime clashes across components)
@@ -16,6 +17,7 @@
 @end
 
 @interface SpectrumPreferences () {
+    NSPopUpButton *_themePopup;
     NSPopUpButton *_barCountPopup;
     NSPopUpButton *_fftSizePopup;
     NSPopUpButton *_barStylePopup;
@@ -57,7 +59,7 @@
 - (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
 
 - (void)loadView {
-    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 780)];
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 810)];
     self.view = view;
     [NSColor setIgnoresAlpha:NO];
     [NSColorPanel sharedColorPanel].showsAlpha = YES;
@@ -169,6 +171,16 @@
     appearanceHeader.frame = NSMakeRect(labelX, y, 200, 17);
     [self.view addSubview:appearanceHeader];
     y += 22;
+
+    [self.view addSubview:[self label:@"Theme:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _themePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 160, 25)];
+    for (int i = 0; i < spectrum_config::kThemeCount; ++i) {
+        [_themePopup addItemWithTitle:[NSString stringWithUTF8String:spectrum_config::kThemes[i].name]];
+    }
+    _themePopup.target = self; _themePopup.action = @selector(themeChanged:);
+    _themePopup.toolTip = @"Apply a color preset to bars, background, and grid";
+    [self.view addSubview:_themePopup];
+    y += 30;
 
     [self.view addSubview:[self label:@"Bar style:" at:NSMakePoint(labelX + 10, y + 3)]];
     _barStylePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 130, 25)];
@@ -338,14 +350,23 @@
     _freqAxisCheckbox.state = getConfigBool(kKeyShowFreqAxis, kDefaultShowFreqAxis) ? NSControlStateValueOn : NSControlStateValueOff;
     _glassCheckbox.state = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground) ? NSControlStateValueOn : NSControlStateValueOff;
 
+    int gridOpacity = (int)getConfigInt(kKeyGridOpacity, kDefaultGridOpacity);
+    _gridOpacitySlider.integerValue = gridOpacity;
+    _gridOpacityLabel.stringValue = [NSString stringWithFormat:@"%d%%", gridOpacity];
+
+    int theme = (int)getConfigInt(kKeyTheme, kDefaultTheme);
+    if (theme < 0 || theme >= kThemeCount) theme = 0;
+    [_themePopup selectItemAtIndex:theme];
+
+    [self reloadColorWells];
+}
+
+- (void)reloadColorWells {
+    using namespace spectrum_config;
     _barColorLightWell.color = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight)];
     _bgColorLightWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight)];
     _barColorDarkWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorDark, kDefaultBarColorDark)];
     _bgColorDarkWell.color   = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorDark, kDefaultBgColorDark)];
-
-    int gridOpacity = (int)getConfigInt(kKeyGridOpacity, kDefaultGridOpacity);
-    _gridOpacitySlider.integerValue = gridOpacity;
-    _gridOpacityLabel.stringValue = [NSString stringWithFormat:@"%d%%", gridOpacity];
     _gridColorLightWell.color = [self colorFromARGB:(uint32_t)getConfigInt(kKeyGridColorLight, kDefaultGridColorLight)];
     _gridColorDarkWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyGridColorDark, kDefaultGridColorDark)];
 }
@@ -459,6 +480,17 @@
     [self notifyChanged];
 }
 
+- (void)themeChanged:(id)sender {
+    using namespace spectrum_config;
+    NSInteger idx = _themePopup.indexOfSelectedItem;
+    setConfigInt(kKeyTheme, idx);
+    if (idx > 0) {
+        applyThemeToConfig((int)idx);
+        [self reloadColorWells];
+    }
+    [self notifyChanged];
+}
+
 - (void)gridOpacityChanged:(id)sender {
     int v = (int)_gridOpacitySlider.integerValue;
     spectrum_config::setConfigInt(spectrum_config::kKeyGridOpacity, v);
@@ -474,6 +506,9 @@
     else if (sender == _bgColorDarkWell)   setConfigInt(kKeyBgColorDark, [self argbFromColor:_bgColorDarkWell.color]);
     else if (sender == _gridColorLightWell) setConfigInt(kKeyGridColorLight, [self argbFromColor:_gridColorLightWell.color]);
     else if (sender == _gridColorDarkWell)  setConfigInt(kKeyGridColorDark, [self argbFromColor:_gridColorDarkWell.color]);
+    // A manual color edit means the palette no longer matches a preset.
+    setConfigInt(kKeyTheme, 0);
+    [_themePopup selectItemAtIndex:0];
     [self notifyChanged];
 }
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -336,10 +336,10 @@
 
     [self selectPopup:_barCountPopup value:(int)getConfigInt(kKeyBarCount, kDefaultBarCount)];
     [self selectPopup:_fftSizePopup value:(int)getConfigInt(kKeyFftSize, kDefaultFftSize)];
-    [_freqScalePopup selectItemAtIndex:getConfigInt(kKeyFreqScale, kDefaultFreqScale)];
-    [_barStylePopup selectItemAtIndex:getConfigInt(kKeyBarStyle, kDefaultBarStyle)];
-    [_drawModePopup selectItemAtIndex:getConfigInt(kKeyDrawMode, kDefaultDrawMode)];
-    [_orientationPopup selectItemAtIndex:getConfigInt(kKeyOrientation, kDefaultOrientation)];
+    [self selectIndexPopup:_freqScalePopup index:getConfigInt(kKeyFreqScale, kDefaultFreqScale)];
+    [self selectIndexPopup:_barStylePopup index:getConfigInt(kKeyBarStyle, kDefaultBarStyle)];
+    [self selectIndexPopup:_drawModePopup index:getConfigInt(kKeyDrawMode, kDefaultDrawMode)];
+    [self selectIndexPopup:_orientationPopup index:getConfigInt(kKeyOrientation, kDefaultOrientation)];
 
     _minHzField.integerValue = getConfigInt(kKeyMinHz, kDefaultMinHz);
     _maxHzField.integerValue = getConfigInt(kKeyMaxHz, kDefaultMaxHz);
@@ -394,6 +394,13 @@
 - (void)selectPopup:(NSPopUpButton *)popup value:(int)value {
     NSInteger idx = [popup indexOfItemWithTitle:[@(value) stringValue]];
     if (idx >= 0) [popup selectItemAtIndex:idx];
+}
+
+// Config values index these popups directly; an out-of-range value from a
+// corrupted config store would raise NSRangeException, so clamp first.
+- (void)selectIndexPopup:(NSPopUpButton *)popup index:(NSInteger)idx {
+    if (idx < 0 || idx >= popup.numberOfItems) idx = 0;
+    [popup selectItemAtIndex:idx];
 }
 
 - (NSColor *)colorFromARGB:(uint32_t)argb {

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -1,0 +1,359 @@
+//
+//  SpectrumPreferences.mm
+//  foo_jl_spectrum_mac
+//
+
+#import "SpectrumPreferences.h"
+#include "../fb2k_sdk.h"
+#include "../Core/SpectrumConfig.h"
+#import "../../../../shared/PreferencesCommon.h"
+
+// Uniquely-named flipped view (avoids ObjC runtime clashes across components)
+@interface SpectrumFlippedView : NSView
+@end
+@implementation SpectrumFlippedView
+- (BOOL)isFlipped { return YES; }
+@end
+
+@interface SpectrumPreferences () {
+    NSPopUpButton *_barCountPopup;
+    NSPopUpButton *_fftSizePopup;
+    NSPopUpButton *_barStylePopup;
+    NSPopUpButton *_freqScalePopup;
+    NSTextField   *_minHzField;
+    NSTextField   *_maxHzField;
+    NSSlider      *_gapSlider;
+    NSTextField   *_gapLabel;
+    NSSlider      *_smoothingSlider;
+    NSTextField   *_smoothingLabel;
+    NSButton      *_peakHoldCheckbox;
+    NSButton      *_dbGuidesCheckbox;
+    NSButton      *_glassCheckbox;
+    NSColorWell   *_barColorLightWell;
+    NSColorWell   *_bgColorLightWell;
+    NSColorWell   *_barColorDarkWell;
+    NSColorWell   *_bgColorDarkWell;
+}
+@end
+
+@implementation SpectrumPreferences
+
+- (instancetype)init {
+    return [super initWithNibName:nil bundle:nil];
+}
+
+- (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
+
+- (void)loadView {
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 500)];
+    self.view = view;
+    [NSColor setIgnoresAlpha:NO];
+    [NSColorPanel sharedColorPanel].showsAlpha = YES;
+    [self buildUI];
+    [self loadSettings];
+}
+
+- (void)buildUI {
+    CGFloat y = 10;
+    const CGFloat labelX = 20;
+    const CGFloat controlX = 150;
+
+    NSTextField *title = JLCreatePreferencesTitle(@"Spectrum Analyzer");
+    title.frame = NSMakeRect(labelX, y, 400, 20);
+    [self.view addSubview:title];
+    y += 30;
+
+    // --- Analysis section ---
+    NSTextField *analysisHeader = JLCreateSectionHeader(@"Analysis");
+    analysisHeader.frame = NSMakeRect(labelX, y, 200, 17);
+    [self.view addSubview:analysisHeader];
+    y += 22;
+
+    [self.view addSubview:[self label:@"Bars:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _barCountPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 100, 25)];
+    for (NSNumber *n in @[@16, @24, @32, @48, @64, @96, @128]) {
+        [_barCountPopup addItemWithTitle:n.stringValue];
+    }
+    _barCountPopup.target = self; _barCountPopup.action = @selector(barCountChanged:);
+    [self.view addSubview:_barCountPopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"FFT size:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _fftSizePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 100, 25)];
+    for (NSNumber *n in @[@1024, @2048, @4096, @8192, @16384]) {
+        [_fftSizePopup addItemWithTitle:n.stringValue];
+    }
+    _fftSizePopup.target = self; _fftSizePopup.action = @selector(fftSizeChanged:);
+    [self.view addSubview:_fftSizePopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Frequency scale:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _freqScalePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 130, 25)];
+    [_freqScalePopup addItemWithTitle:@"Logarithmic"];
+    [_freqScalePopup addItemWithTitle:@"Linear"];
+    _freqScalePopup.target = self; _freqScalePopup.action = @selector(freqScaleChanged:);
+    [self.view addSubview:_freqScalePopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Range (Hz):" at:NSMakePoint(labelX + 10, y + 3)]];
+    _minHzField = [[NSTextField alloc] initWithFrame:NSMakeRect(controlX, y, 70, 22)];
+    _minHzField.formatter = [self intFormatterMin:10 max:2000];
+    _minHzField.target = self; _minHzField.action = @selector(rangeChanged:);
+    [self.view addSubview:_minHzField];
+    [self.view addSubview:[self label:@"to" at:NSMakePoint(controlX + 78, y + 3)]];
+    _maxHzField = [[NSTextField alloc] initWithFrame:NSMakeRect(controlX + 100, y, 70, 22)];
+    _maxHzField.formatter = [self intFormatterMin:1000 max:24000];
+    _maxHzField.target = self; _maxHzField.action = @selector(rangeChanged:);
+    [self.view addSubview:_maxHzField];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Smoothing:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _smoothingSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _smoothingSlider.minValue = 0; _smoothingSlider.maxValue = 100; _smoothingSlider.continuous = YES;
+    _smoothingSlider.target = self; _smoothingSlider.action = @selector(smoothingChanged:);
+    [self.view addSubview:_smoothingSlider];
+    _smoothingLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_smoothingLabel];
+    y += 34;
+
+    // --- Appearance section ---
+    NSTextField *appearanceHeader = JLCreateSectionHeader(@"Appearance");
+    appearanceHeader.frame = NSMakeRect(labelX, y, 200, 17);
+    [self.view addSubview:appearanceHeader];
+    y += 22;
+
+    [self.view addSubview:[self label:@"Bar style:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _barStylePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(controlX, y, 130, 25)];
+    [_barStylePopup addItemWithTitle:@"Solid"];
+    [_barStylePopup addItemWithTitle:@"Gradient"];
+    [_barStylePopup addItemWithTitle:@"Spectrum"];
+    _barStylePopup.target = self; _barStylePopup.action = @selector(barStyleChanged:);
+    [self.view addSubview:_barStylePopup];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Bar gap:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _gapSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _gapSlider.minValue = 0; _gapSlider.maxValue = 80; _gapSlider.continuous = YES;
+    _gapSlider.target = self; _gapSlider.action = @selector(gapChanged:);
+    [self.view addSubview:_gapSlider];
+    _gapLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_gapLabel];
+    y += 30;
+
+    _peakHoldCheckbox = [self checkbox:@"Show peak caps" at:NSMakePoint(labelX + 10, y)];
+    [self.view addSubview:_peakHoldCheckbox];
+    y += 26;
+
+    _dbGuidesCheckbox = [self checkbox:@"Show dB scale" at:NSMakePoint(labelX + 10, y)];
+    _dbGuidesCheckbox.toolTip = @"Draw decibel guide lines and labels on the right edge";
+    [self.view addSubview:_dbGuidesCheckbox];
+    y += 26;
+
+    _glassCheckbox = [self checkbox:@"Glass background" at:NSMakePoint(labelX + 10, y)];
+    _glassCheckbox.toolTip = @"Translucent blur background instead of a solid color";
+    [self.view addSubview:_glassCheckbox];
+    y += 32;
+
+    // Colors - light
+    [self.view addSubview:[self label:@"Colors (Light Mode)" at:NSMakePoint(labelX, y)]];
+    y += 22;
+    [self.view addSubview:[self label:@"Bars:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _barColorLightWell = [self colorWellAt:NSMakePoint(controlX, y)];
+    [self.view addSubview:_barColorLightWell];
+    [self.view addSubview:[self label:@"Background:" at:NSMakePoint(controlX + 60, y + 3)]];
+    _bgColorLightWell = [self colorWellAt:NSMakePoint(controlX + 150, y)];
+    [self.view addSubview:_bgColorLightWell];
+    y += 32;
+
+    // Colors - dark
+    [self.view addSubview:[self label:@"Colors (Dark Mode)" at:NSMakePoint(labelX, y)]];
+    y += 22;
+    [self.view addSubview:[self label:@"Bars:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _barColorDarkWell = [self colorWellAt:NSMakePoint(controlX, y)];
+    [self.view addSubview:_barColorDarkWell];
+    [self.view addSubview:[self label:@"Background:" at:NSMakePoint(controlX + 60, y + 3)]];
+    _bgColorDarkWell = [self colorWellAt:NSMakePoint(controlX + 150, y)];
+    [self.view addSubview:_bgColorDarkWell];
+    y += 32;
+}
+
+#pragma mark - Control factory helpers
+
+- (NSTextField *)label:(NSString *)text at:(NSPoint)p {
+    NSTextField *l = [[NSTextField alloc] initWithFrame:NSMakeRect(p.x, p.y, 200, 17)];
+    l.stringValue = text; l.editable = NO; l.bordered = NO;
+    l.backgroundColor = [NSColor clearColor];
+    l.font = [NSFont systemFontOfSize:11];
+    return l;
+}
+
+- (NSTextField *)valueLabelAt:(NSPoint)p {
+    NSTextField *l = [[NSTextField alloc] initWithFrame:NSMakeRect(p.x, p.y, 50, 17)];
+    l.editable = NO; l.bordered = NO;
+    l.backgroundColor = [NSColor clearColor];
+    l.font = [NSFont systemFontOfSize:11];
+    return l;
+}
+
+- (NSButton *)checkbox:(NSString *)title at:(NSPoint)p {
+    NSButton *b = [[NSButton alloc] initWithFrame:NSMakeRect(p.x, p.y, 260, 20)];
+    b.buttonType = NSButtonTypeSwitch;
+    b.title = title;
+    b.target = self; b.action = @selector(checkboxChanged:);
+    return b;
+}
+
+- (NSColorWell *)colorWellAt:(NSPoint)p {
+    NSColorWell *w = [[NSColorWell alloc] initWithFrame:NSMakeRect(p.x, p.y, 40, 24)];
+    w.target = self; w.action = @selector(colorChanged:);
+    if (@available(macOS 13.0, *)) { w.colorWellStyle = NSColorWellStyleMinimal; }
+    return w;
+}
+
+- (NSNumberFormatter *)intFormatterMin:(int)lo max:(int)hi {
+    NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
+    f.numberStyle = NSNumberFormatterNoStyle;
+    f.minimum = @(lo); f.maximum = @(hi);
+    f.allowsFloats = NO;
+    return f;
+}
+
+#pragma mark - Load / persist
+
+- (void)loadSettings {
+    using namespace spectrum_config;
+
+    [self selectPopup:_barCountPopup value:(int)getConfigInt(kKeyBarCount, kDefaultBarCount)];
+    [self selectPopup:_fftSizePopup value:(int)getConfigInt(kKeyFftSize, kDefaultFftSize)];
+    [_freqScalePopup selectItemAtIndex:getConfigInt(kKeyFreqScale, kDefaultFreqScale)];
+    [_barStylePopup selectItemAtIndex:getConfigInt(kKeyBarStyle, kDefaultBarStyle)];
+
+    _minHzField.integerValue = getConfigInt(kKeyMinHz, kDefaultMinHz);
+    _maxHzField.integerValue = getConfigInt(kKeyMaxHz, kDefaultMaxHz);
+
+    int smoothing = (int)getConfigInt(kKeySmoothing, kDefaultSmoothing);
+    _smoothingSlider.integerValue = smoothing;
+    _smoothingLabel.stringValue = [NSString stringWithFormat:@"%d%%", smoothing];
+
+    int gap = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
+    _gapSlider.integerValue = gap;
+    _gapLabel.stringValue = [NSString stringWithFormat:@"%d%%", gap];
+
+    _peakHoldCheckbox.state = getConfigBool(kKeyPeakHold, kDefaultPeakHold) ? NSControlStateValueOn : NSControlStateValueOff;
+    _dbGuidesCheckbox.state = getConfigBool(kKeyShowDbGuides, kDefaultShowDbGuides) ? NSControlStateValueOn : NSControlStateValueOff;
+    _glassCheckbox.state = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground) ? NSControlStateValueOn : NSControlStateValueOff;
+
+    _barColorLightWell.color = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight)];
+    _bgColorLightWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight)];
+    _barColorDarkWell.color  = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBarColorDark, kDefaultBarColorDark)];
+    _bgColorDarkWell.color   = [self colorFromARGB:(uint32_t)getConfigInt(kKeyBgColorDark, kDefaultBgColorDark)];
+}
+
+- (void)selectPopup:(NSPopUpButton *)popup value:(int)value {
+    NSInteger idx = [popup indexOfItemWithTitle:[@(value) stringValue]];
+    if (idx >= 0) [popup selectItemAtIndex:idx];
+}
+
+- (NSColor *)colorFromARGB:(uint32_t)argb {
+    return [NSColor colorWithSRGBRed:((argb >> 16) & 0xFF) / 255.0
+                               green:((argb >> 8) & 0xFF) / 255.0
+                                blue:(argb & 0xFF) / 255.0
+                               alpha:((argb >> 24) & 0xFF) / 255.0];
+}
+
+- (uint32_t)argbFromColor:(NSColor *)color {
+    NSColor *c = [color colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
+    if (!c) return 0xFF000000;
+    uint32_t a = (uint32_t)(c.alphaComponent * 255) & 0xFF;
+    uint32_t r = (uint32_t)(c.redComponent * 255) & 0xFF;
+    uint32_t g = (uint32_t)(c.greenComponent * 255) & 0xFF;
+    uint32_t b = (uint32_t)(c.blueComponent * 255) & 0xFF;
+    return (a << 24) | (r << 16) | (g << 8) | b;
+}
+
+- (void)notifyChanged {
+    [[NSNotificationCenter defaultCenter] postNotificationName:spectrum_config::kSettingsChangedNotification object:nil];
+}
+
+#pragma mark - Actions
+
+- (void)barCountChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyBarCount, _barCountPopup.titleOfSelectedItem.intValue);
+    [self notifyChanged];
+}
+
+- (void)fftSizeChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyFftSize, _fftSizePopup.titleOfSelectedItem.intValue);
+    [self notifyChanged];
+}
+
+- (void)freqScaleChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyFreqScale, _freqScalePopup.indexOfSelectedItem);
+    [self notifyChanged];
+}
+
+- (void)barStyleChanged:(id)sender {
+    spectrum_config::setConfigInt(spectrum_config::kKeyBarStyle, _barStylePopup.indexOfSelectedItem);
+    [self notifyChanged];
+}
+
+- (void)rangeChanged:(id)sender {
+    using namespace spectrum_config;
+    int lo = _minHzField.intValue;
+    int hi = _maxHzField.intValue;
+    if (hi <= lo + 100) { hi = lo + 100; _maxHzField.integerValue = hi; }
+    setConfigInt(kKeyMinHz, lo);
+    setConfigInt(kKeyMaxHz, hi);
+    [self notifyChanged];
+}
+
+- (void)smoothingChanged:(id)sender {
+    int v = (int)_smoothingSlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeySmoothing, v);
+    _smoothingLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
+- (void)gapChanged:(id)sender {
+    int v = (int)_gapSlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeyGapPercent, v);
+    _gapLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
+- (void)checkboxChanged:(id)sender {
+    using namespace spectrum_config;
+    if (sender == _peakHoldCheckbox) {
+        setConfigBool(kKeyPeakHold, _peakHoldCheckbox.state == NSControlStateValueOn);
+    } else if (sender == _dbGuidesCheckbox) {
+        setConfigBool(kKeyShowDbGuides, _dbGuidesCheckbox.state == NSControlStateValueOn);
+    } else if (sender == _glassCheckbox) {
+        setConfigBool(kKeyGlassBackground, _glassCheckbox.state == NSControlStateValueOn);
+    }
+    [self notifyChanged];
+}
+
+- (void)colorChanged:(id)sender {
+    using namespace spectrum_config;
+    if (sender == _barColorLightWell)      setConfigInt(kKeyBarColorLight, [self argbFromColor:_barColorLightWell.color]);
+    else if (sender == _bgColorLightWell)  setConfigInt(kKeyBgColorLight, [self argbFromColor:_bgColorLightWell.color]);
+    else if (sender == _barColorDarkWell)  setConfigInt(kKeyBarColorDark, [self argbFromColor:_barColorDarkWell.color]);
+    else if (sender == _bgColorDarkWell)   setConfigInt(kKeyBgColorDark, [self argbFromColor:_bgColorDarkWell.color]);
+    [self notifyChanged];
+}
+
+@end
+
+// --- Preferences page registration ---
+namespace {
+    class spectrum_preferences_page : public preferences_page {
+    public:
+        service_ptr instantiate() override {
+            return fb2k::wrapNSObject([[SpectrumPreferences alloc] init]);
+        }
+        const char* get_name() override { return "Spectrum Analyzer"; }
+        GUID get_guid() override { return spectrum_config::guid_preferences_page; }
+        GUID get_parent_guid() override { return preferences_page::guid_display; }
+    };
+    FB2K_SERVICE_FACTORY(spectrum_preferences_page);
+}

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumPreferences.mm
@@ -26,6 +26,12 @@
     NSTextField   *_gapLabel;
     NSSlider      *_smoothingSlider;
     NSTextField   *_smoothingLabel;
+    NSSlider      *_shadowFallSlider;
+    NSTextField   *_shadowFallLabel;
+    NSSlider      *_peakFallSlider;
+    NSTextField   *_peakFallLabel;
+    NSSlider      *_peakHoldSlider;
+    NSTextField   *_peakHoldLabel;
     NSButton      *_peakHoldCheckbox;
     NSButton      *_shadowFillCheckbox;
     NSButton      *_dbGuidesCheckbox;
@@ -47,7 +53,7 @@
 - (NSString *)preferencesTitle { return @"Spectrum Analyzer"; }
 
 - (void)loadView {
-    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 560)];
+    SpectrumFlippedView *view = [[SpectrumFlippedView alloc] initWithFrame:NSMakeRect(0, 0, 460, 690)];
     self.view = view;
     [NSColor setIgnoresAlpha:NO];
     [NSColorPanel sharedColorPanel].showsAlpha = YES;
@@ -116,6 +122,42 @@
     [self.view addSubview:_smoothingSlider];
     _smoothingLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
     [self.view addSubview:_smoothingLabel];
+    y += 34;
+
+    // --- Dynamics section ---
+    NSTextField *dynamicsHeader = JLCreateSectionHeader(@"Dynamics");
+    dynamicsHeader.frame = NSMakeRect(labelX, y, 200, 17);
+    [self.view addSubview:dynamicsHeader];
+    y += 22;
+
+    [self.view addSubview:[self label:@"Shadow fall:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _shadowFallSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _shadowFallSlider.minValue = 0; _shadowFallSlider.maxValue = 100; _shadowFallSlider.continuous = YES;
+    _shadowFallSlider.target = self; _shadowFallSlider.action = @selector(shadowFallChanged:);
+    _shadowFallSlider.toolTip = @"How fast the shadow band falls (higher = faster)";
+    [self.view addSubview:_shadowFallSlider];
+    _shadowFallLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_shadowFallLabel];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Peak fall:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _peakFallSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _peakFallSlider.minValue = 0; _peakFallSlider.maxValue = 100; _peakFallSlider.continuous = YES;
+    _peakFallSlider.target = self; _peakFallSlider.action = @selector(peakFallChanged:);
+    _peakFallSlider.toolTip = @"How fast the peak line falls after its hold (higher = faster)";
+    [self.view addSubview:_peakFallSlider];
+    _peakFallLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_peakFallLabel];
+    y += 30;
+
+    [self.view addSubview:[self label:@"Peak hold:" at:NSMakePoint(labelX + 10, y + 3)]];
+    _peakHoldSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(controlX, y, 150, 22)];
+    _peakHoldSlider.minValue = 0; _peakHoldSlider.maxValue = 2000; _peakHoldSlider.continuous = YES;
+    _peakHoldSlider.target = self; _peakHoldSlider.action = @selector(peakHoldMsChanged:);
+    _peakHoldSlider.toolTip = @"How long the peak line stays before it starts to fall";
+    [self.view addSubview:_peakHoldSlider];
+    _peakHoldLabel = [self valueLabelAt:NSMakePoint(controlX + 160, y + 2)];
+    [self.view addSubview:_peakHoldLabel];
     y += 34;
 
     // --- Appearance section ---
@@ -247,6 +289,18 @@
     _smoothingSlider.integerValue = smoothing;
     _smoothingLabel.stringValue = [NSString stringWithFormat:@"%d%%", smoothing];
 
+    int shadowFall = (int)getConfigInt(kKeyShadowFallSpeed, kDefaultShadowFallSpeed);
+    _shadowFallSlider.integerValue = shadowFall;
+    _shadowFallLabel.stringValue = [NSString stringWithFormat:@"%d%%", shadowFall];
+
+    int peakFall = (int)getConfigInt(kKeyPeakFallSpeed, kDefaultPeakFallSpeed);
+    _peakFallSlider.integerValue = peakFall;
+    _peakFallLabel.stringValue = [NSString stringWithFormat:@"%d%%", peakFall];
+
+    int peakHoldMs = (int)getConfigInt(kKeyPeakHoldMs, kDefaultPeakHoldMs);
+    _peakHoldSlider.integerValue = peakHoldMs;
+    _peakHoldLabel.stringValue = [NSString stringWithFormat:@"%dms", peakHoldMs];
+
     int gap = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
     _gapSlider.integerValue = gap;
     _gapLabel.stringValue = [NSString stringWithFormat:@"%d%%", gap];
@@ -325,6 +379,27 @@
     int v = (int)_smoothingSlider.integerValue;
     spectrum_config::setConfigInt(spectrum_config::kKeySmoothing, v);
     _smoothingLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
+- (void)shadowFallChanged:(id)sender {
+    int v = (int)_shadowFallSlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeyShadowFallSpeed, v);
+    _shadowFallLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
+- (void)peakFallChanged:(id)sender {
+    int v = (int)_peakFallSlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeyPeakFallSpeed, v);
+    _peakFallLabel.stringValue = [NSString stringWithFormat:@"%d%%", v];
+    [self notifyChanged];
+}
+
+- (void)peakHoldMsChanged:(id)sender {
+    int v = (int)_peakHoldSlider.integerValue;
+    spectrum_config::setConfigInt(spectrum_config::kKeyPeakHoldMs, v);
+    _peakHoldLabel.stringValue = [NSString stringWithFormat:@"%dms", v];
     [self notifyChanged];
 }
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.h
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.h
@@ -1,0 +1,35 @@
+//
+//  SpectrumView.h
+//  foo_jl_spectrum_mac
+//
+//  Core Graphics view that renders frequency bars with falling peak caps.
+//
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SpectrumView;
+
+@protocol SpectrumViewDelegate <NSObject>
+- (void)spectrumViewRequestsContextMenu:(SpectrumView *)view atPoint:(NSPoint)point;
+@end
+
+@interface SpectrumView : NSView
+
+@property (nonatomic, weak, nullable) id<SpectrumViewDelegate> delegate;
+
+// Whether audio is currently being displayed (affects the idle placeholder).
+@property (nonatomic) BOOL playing;
+
+// Re-read display settings (colors, style, gap, peak hold) from config.
+- (void)reloadSettings;
+
+// Provide the latest bar magnitudes and peak positions (each 0..1) and redraw.
+- (void)setBarsData:(const float *)bars peaks:(const float *)peaks count:(NSInteger)count;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.h
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.h
@@ -27,8 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 // Re-read display settings (colors, style, gap, peak hold) from config.
 - (void)reloadSettings;
 
-// Provide the latest bar magnitudes and peak positions (each 0..1) and redraw.
-- (void)setBarsData:(const float *)bars peaks:(const float *)peaks count:(NSInteger)count;
+// Provide the latest bar magnitudes, shadow fill, and peak positions
+// (each 0..1, `count` entries) and redraw.
+- (void)setBarsData:(const float *)bars
+             shadow:(const float *)shadow
+              peaks:(const float *)peaks
+              count:(NSInteger)count;
 
 @end
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -16,10 +16,18 @@
 
     // Cached settings (refreshed via reloadSettings)
     int      _barStyle;
+    int      _drawMode;
+    bool     _vertical;
     int      _gapPercent;
     int      _minHz;
     int      _maxHz;
     bool     _logScale;
+
+    // Transient plot geometry (set each drawRect). Frequency runs along one
+    // axis, magnitude along the other, depending on orientation.
+    CGFloat  _pOx, _pOy;   // plot origin (left, bottom)
+    CGFloat  _pFreq;       // pixels along the frequency axis
+    CGFloat  _pMag;        // pixels along the magnitude axis
     bool     _peakHold;
     bool     _shadowFill;
     bool     _showDbGuides;
@@ -48,6 +56,8 @@
 - (void)reloadSettings {
     using namespace spectrum_config;
     _barStyle      = (int)getConfigInt(kKeyBarStyle, kDefaultBarStyle);
+    _drawMode      = (int)getConfigInt(kKeyDrawMode, kDefaultDrawMode);
+    _vertical      = getConfigInt(kKeyOrientation, kDefaultOrientation) == OrientationVertical;
     _gapPercent    = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
     _minHz         = (int)getConfigInt(kKeyMinHz, kDefaultMinHz);
     _maxHz         = (int)getConfigInt(kKeyMaxHz, kDefaultMaxHz);
@@ -126,6 +136,13 @@ static NSColor *colorFromARGB(uint32_t argb) {
 
 #pragma mark - Drawing
 
+// Map a frequency fraction (0..1) and magnitude (0..1) to a screen point,
+// honoring the current orientation. Uses the transient plot geometry.
+- (CGPoint)mapF:(CGFloat)f mag:(CGFloat)m {
+    if (_vertical) return CGPointMake(_pOx + m * _pMag, _pOy + f * _pFreq);
+    return CGPointMake(_pOx + f * _pFreq, _pOy + m * _pMag);
+}
+
 - (void)drawRect:(NSRect)dirtyRect {
     [super drawRect:dirtyRect];
 
@@ -134,164 +151,249 @@ static NSColor *colorFromARGB(uint32_t argb) {
     const CGFloat W = bounds.size.width;
     const CGFloat H = bounds.size.height;
 
-    // Background
     if (!_glass) {
         CGContextSetFillColorWithColor(ctx, [self bgColor].CGColor);
         CGContextFillRect(ctx, bounds);
     }
 
     const NSInteger n = (NSInteger)_bars.size();
-    if (n <= 0) {
-        [self drawPlaceholder:bounds];
-        return;
+    if (n <= 0) { [self drawPlaceholder:bounds]; return; }
+
+    // The magnitude axis needs a wide margin for "-80dB" labels; the frequency
+    // axis a thin one. Which screen edge holds which depends on orientation.
+    const CGFloat dbThick = 34.0;    // along the magnitude axis
+    const CGFloat freqThick = 13.0;  // along the frequency axis
+
+    BOOL drawDb, drawFreq;
+    CGFloat rightMargin = 0, bottomMargin = 0;
+    if (_vertical) {
+        drawDb   = _showDbGuides  && (H > 50.0);   // dB labels along the bottom
+        drawFreq = _showFreqAxis  && (W > 80.0);   // freq labels along the right
+        bottomMargin = drawDb   ? freqThick : 0.0;
+        rightMargin  = drawFreq ? dbThick   : 0.0;
+    } else {
+        drawDb   = _showDbGuides  && (W > 80.0);   // dB labels along the right
+        drawFreq = _showFreqAxis  && (H > 50.0);   // freq labels along the bottom
+        rightMargin  = drawDb   ? dbThick   : 0.0;
+        bottomMargin = drawFreq ? freqThick : 0.0;
     }
 
-    // Reserve margins: right for the dB scale, bottom for frequency labels.
-    const CGFloat dbMargin = 34.0;
-    const CGFloat freqMargin = 13.0;
-    const BOOL drawDb   = _showDbGuides && (W > dbMargin + 40.0);
-    const BOOL drawFreq = _showFreqAxis && (H > freqMargin + 30.0);
+    const CGFloat plotW = W - rightMargin;
+    const CGFloat plotH = H - bottomMargin - 2.0;
+    if (plotW <= 1.0 || plotH <= 1.0) return;
 
-    const CGFloat plotW = drawDb ? (W - dbMargin) : W;
-    const CGFloat plotBottom = drawFreq ? freqMargin : 0.0;
-    const CGFloat plotH = H - plotBottom - 2.0;
-    if (plotH <= 1.0) return;
+    _pOx = 0.0;
+    _pOy = bottomMargin;
+    _pFreq = _vertical ? plotH : plotW;
+    _pMag  = _vertical ? plotW : plotH;
 
-    // Grid behind the bars.
-    if (drawFreq) [self drawFreqAxisWithPlotWidth:plotW plotBottom:plotBottom plotHeight:plotH context:ctx];
-    if (drawDb)   [self drawDbGuidesWithPlotWidth:plotW plotBottom:plotBottom plotHeight:plotH context:ctx];
-
-    const CGFloat slot = plotW / (CGFloat)n;
-    CGFloat gap = slot * (_gapPercent / 100.0);
-    if (gap > slot - 1.0) gap = slot - 1.0;
-    if (gap < 0) gap = 0;
-    const CGFloat barW = slot - gap;
+    // Grid behind the spectrum.
+    if (drawFreq) [self drawFreqAxisInContext:ctx];
+    if (drawDb)   [self drawDbGuidesInContext:ctx];
 
     NSColor *base = [self barColor];
     const BOOL dark = fb2k_ui::isDarkMode();
-    // Shadow band: a muted grey-blue so it reads distinctly above the bar.
     NSColor *shadowColor = [base blendedColorWithFraction:0.6 ofColor:[NSColor grayColor]];
-    // Peak line: high-contrast against the background in either theme.
     NSColor *capColor = dark ? [base blendedColorWithFraction:0.7 ofColor:[NSColor whiteColor]]
                              : [base blendedColorWithFraction:0.5 ofColor:[NSColor blackColor]];
 
+    if (_drawMode == spectrum_config::DrawModeCurve) {
+        [self drawCurveBase:base shadow:shadowColor cap:capColor context:ctx];
+    } else {
+        [self drawBarsBase:base shadow:shadowColor cap:capColor count:n context:ctx];
+    }
+}
+
+#pragma mark - Bars
+
+- (void)drawBarsBase:(NSColor *)base
+              shadow:(NSColor *)shadowColor
+                 cap:(NSColor *)capColor
+               count:(NSInteger)n
+             context:(CGContextRef)ctx {
+    const CGFloat slot = _pFreq / (CGFloat)n;
+    CGFloat gap = slot * (_gapPercent / 100.0);
+    if (gap > slot - 1.0) gap = slot - 1.0;
+    if (gap < 0) gap = 0;
+    const CGFloat th = slot - gap;
+
     for (NSInteger i = 0; i < n; ++i) {
-        CGFloat x = (CGFloat)i * slot + gap * 0.5;
+        const CGFloat off = (CGFloat)i * slot + gap * 0.5;
 
         CGFloat bv = _bars[i];  if (bv < 0) bv = 0; else if (bv > 1) bv = 1;
-        CGFloat barH = bv * plotH;
 
-        // Shadow fill (slow-decaying) behind the bright bar.
         if (_shadowFill) {
             CGFloat sv = _shadow[i]; if (sv < 0) sv = 0; else if (sv > 1) sv = 1;
-            CGFloat sh = sv * plotH;
-            if (sh > barH + 0.5) {
+            if (sv > bv + 0.005) {
                 CGContextSetFillColorWithColor(ctx, shadowColor.CGColor);
-                CGContextFillRect(ctx, CGRectMake(x, plotBottom, barW, sh));
+                CGContextFillRect(ctx, [self barRectAtOffset:off thickness:th magnitude:sv]);
             }
         }
 
-        // Bright instantaneous bar.
-        if (barH >= 1.0) {
-            [self fillBar:CGRectMake(x, plotBottom, barW, barH) index:i count:n base:base context:ctx];
+        if (bv * _pMag >= 1.0) {
+            [self fillBarRect:[self barRectAtOffset:off thickness:th magnitude:bv]
+                        index:i count:n base:base context:ctx];
         }
 
-        // Peak cap.
         if (_peakHold) {
             CGFloat pv = _peaks[i]; if (pv < 0) pv = 0; else if (pv > 1) pv = 1;
             if (pv > 0.001) {
-                CGFloat py = plotBottom + pv * plotH;
                 CGContextSetFillColorWithColor(ctx, capColor.CGColor);
-                CGContextFillRect(ctx, CGRectMake(x, py, barW, 2.0));
+                CGContextFillRect(ctx, [self capRectAtOffset:off thickness:th magnitude:pv]);
             }
         }
     }
 }
 
-- (void)fillBar:(CGRect)r
-          index:(NSInteger)i
-          count:(NSInteger)n
-           base:(NSColor *)base
-        context:(CGContextRef)ctx {
+// A bar filled from the baseline (magnitude 0) to `m`, `th` thick along freq.
+- (CGRect)barRectAtOffset:(CGFloat)off thickness:(CGFloat)th magnitude:(CGFloat)m {
+    if (_vertical) return CGRectMake(_pOx, _pOy + off, m * _pMag, th);
+    return CGRectMake(_pOx + off, _pOy, th, m * _pMag);
+}
+
+// A thin peak cap at magnitude `m`.
+- (CGRect)capRectAtOffset:(CGFloat)off thickness:(CGFloat)th magnitude:(CGFloat)m {
+    if (_vertical) return CGRectMake(_pOx + m * _pMag, _pOy + off, 2.0, th);
+    return CGRectMake(_pOx + off, _pOy + m * _pMag, th, 2.0);
+}
+
+- (void)fillBarRect:(CGRect)r
+              index:(NSInteger)i
+              count:(NSInteger)n
+               base:(NSColor *)base
+            context:(CGContextRef)ctx {
     using namespace spectrum_config;
+    const CGFloat gradAngle = _vertical ? 0.0 : 90.0;  // along the magnitude axis
 
     if (_barStyle == BarStyleSpectrum) {
-        // Hue mapped across frequency: low = blue, high = red.
         CGFloat hue = 0.75 * (CGFloat)i / (CGFloat)MAX(1, n - 1);
         CGFloat h = (0.66 - hue); if (h < 0) h = 0;
-        NSColor *c = [NSColor colorWithHue:h
-                               saturation:0.85
-                               brightness:fb2k_ui::isDarkMode() ? 1.0 : 0.9
-                                    alpha:1.0];
+        NSColor *c = [NSColor colorWithHue:h saturation:0.85
+                               brightness:fb2k_ui::isDarkMode() ? 1.0 : 0.9 alpha:1.0];
         CGContextSetFillColorWithColor(ctx, c.CGColor);
         CGContextFillRect(ctx, r);
         return;
     }
 
     if (_barStyle == BarStyleGradient) {
-        NSColor *bottom = [base blendedColorWithFraction:0.55 ofColor:[NSColor blackColor]];
-        NSColor *top = [base blendedColorWithFraction:0.25 ofColor:[NSColor whiteColor]];
-        NSGradient *grad = [[NSGradient alloc] initWithStartingColor:bottom endingColor:top];
-        [grad drawInBezierPath:[NSBezierPath bezierPathWithRect:r] angle:90.0];
+        NSColor *lo = [base blendedColorWithFraction:0.55 ofColor:[NSColor blackColor]];
+        NSColor *hi = [base blendedColorWithFraction:0.25 ofColor:[NSColor whiteColor]];
+        NSGradient *grad = [[NSGradient alloc] initWithStartingColor:lo endingColor:hi];
+        [grad drawInBezierPath:[NSBezierPath bezierPathWithRect:r] angle:gradAngle];
         return;
     }
 
-    // Solid
     CGContextSetFillColorWithColor(ctx, base.CGColor);
     CGContextFillRect(ctx, r);
 }
 
+#pragma mark - Curve
+
+- (void)drawCurveBase:(NSColor *)base
+               shadow:(NSColor *)shadowColor
+                  cap:(NSColor *)capColor
+              context:(CGContextRef)ctx {
+    // Shadow area behind, then the filled instantaneous curve, then peak line.
+    if (_shadowFill) {
+        [[shadowColor colorWithAlphaComponent:0.35] setFill];
+        [[self areaPathForValues:_shadow] fill];
+    }
+
+    NSBezierPath *area = [self areaPathForValues:_bars];
+    NSGradient *grad = [[NSGradient alloc]
+        initWithStartingColor:[base colorWithAlphaComponent:0.10]
+                  endingColor:[base colorWithAlphaComponent:0.65]];
+    [grad drawInBezierPath:area angle:(_vertical ? 0.0 : 90.0)];
+
+    NSBezierPath *line = [self linePathForValues:_bars];
+    line.lineWidth = 1.5;
+    [base setStroke];
+    [line stroke];
+
+    if (_peakHold) {
+        NSBezierPath *peak = [self linePathForValues:_peaks];
+        peak.lineWidth = 1.5;
+        [capColor setStroke];
+        [peak stroke];
+    }
+}
+
+- (NSBezierPath *)areaPathForValues:(const std::vector<float> &)v {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    const NSInteger n = (NSInteger)v.size();
+    if (n <= 0) return p;
+    [p moveToPoint:[self mapF:0.5 / n mag:0.0]];
+    for (NSInteger i = 0; i < n; ++i) {
+        CGFloat m = v[i]; if (m < 0) m = 0; else if (m > 1) m = 1;
+        [p lineToPoint:[self mapF:((CGFloat)i + 0.5) / n mag:m]];
+    }
+    [p lineToPoint:[self mapF:((CGFloat)n - 0.5) / n mag:0.0]];
+    [p closePath];
+    return p;
+}
+
+- (NSBezierPath *)linePathForValues:(const std::vector<float> &)v {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    const NSInteger n = (NSInteger)v.size();
+    for (NSInteger i = 0; i < n; ++i) {
+        CGFloat m = v[i]; if (m < 0) m = 0; else if (m > 1) m = 1;
+        CGPoint pt = [self mapF:((CGFloat)i + 0.5) / n mag:m];
+        if (i == 0) [p moveToPoint:pt]; else [p lineToPoint:pt];
+    }
+    return p;
+}
+
 #pragma mark - Grids
 
-- (void)drawDbGuidesWithPlotWidth:(CGFloat)plotW
-                       plotBottom:(CGFloat)plotBottom
-                       plotHeight:(CGFloat)plotH
-                          context:(CGContextRef)ctx {
+// dB guides: lines of constant magnitude across the frequency axis.
+- (void)drawDbGuidesInContext:(CGContextRef)ctx {
     const float floorDb = spectrum_config::kDisplayFloorDb;
     const float ceilDb  = spectrum_config::kDisplayCeilDb;
     const float range   = ceilDb - floorDb;
     if (range <= 0) return;
 
     const int step = 10;
-    NSColor *lineColor = [self gridLineColor];
     NSDictionary *attrs = @{
         NSFontAttributeName: [NSFont monospacedDigitSystemFontOfSize:9 weight:NSFontWeightRegular],
         NSForegroundColorAttributeName: [self gridLabelColor]
     };
-
     CGContextSetLineWidth(ctx, 1.0);
-    CGContextSetStrokeColorWithColor(ctx, lineColor.CGColor);
+    CGContextSetStrokeColorWithColor(ctx, [self gridLineColor].CGColor);
 
     int startDb = (int)(std::floor(ceilDb / step) * step);
     for (int db = startDb; db > (int)floorDb; db -= step) {
         CGFloat v = (db - floorDb) / range;
-        CGFloat y = std::round(plotBottom + v * plotH) + 0.5;
-
-        CGContextBeginPath(ctx);
-        CGContextMoveToPoint(ctx, 0, y);
-        CGContextAddLineToPoint(ctx, plotW, y);
-        CGContextStrokePath(ctx);
-
         NSString *label = [NSString stringWithFormat:@"%ddB", db];
         NSSize sz = [label sizeWithAttributes:attrs];
-        [label drawAtPoint:NSMakePoint(plotW + 5, y - sz.height / 2) withAttributes:attrs];
+
+        if (_vertical) {
+            CGFloat x = std::round(_pOx + v * _pMag) + 0.5;
+            CGContextBeginPath(ctx);
+            CGContextMoveToPoint(ctx, x, _pOy);
+            CGContextAddLineToPoint(ctx, x, _pOy + _pFreq);
+            CGContextStrokePath(ctx);
+            [label drawAtPoint:NSMakePoint(x - sz.width / 2, (_pOy - sz.height) / 2) withAttributes:attrs];
+        } else {
+            CGFloat y = std::round(_pOy + v * _pMag) + 0.5;
+            CGContextBeginPath(ctx);
+            CGContextMoveToPoint(ctx, _pOx, y);
+            CGContextAddLineToPoint(ctx, _pOx + _pFreq, y);
+            CGContextStrokePath(ctx);
+            [label drawAtPoint:NSMakePoint(_pOx + _pFreq + 5, y - sz.height / 2) withAttributes:attrs];
+        }
     }
 }
 
-- (void)drawFreqAxisWithPlotWidth:(CGFloat)plotW
-                       plotBottom:(CGFloat)plotBottom
-                       plotHeight:(CGFloat)plotH
-                          context:(CGContextRef)ctx {
-    NSColor *lineColor = [self gridLineColor];
+// Frequency axis: lines of constant frequency across the magnitude axis.
+- (void)drawFreqAxisInContext:(CGContextRef)ctx {
     NSDictionary *attrs = @{
         NSFontAttributeName: [NSFont systemFontOfSize:8 weight:NSFontWeightRegular],
         NSForegroundColorAttributeName: [self gridLabelColor]
     };
-
     CGContextSetLineWidth(ctx, 1.0);
-    CGContextSetStrokeColorWithColor(ctx, lineColor.CGColor);
+    CGContextSetStrokeColorWithColor(ctx, [self gridLineColor].CGColor);
 
-    CGFloat lastLabelRight = -1000.0;
+    CGFloat lastLabelEdge = -1000.0;
 
     // Ticks at 1..9 x 10^e (10,20,..,90,100,..,900,1k,..,20k).
     for (int e = 1; e <= 5; ++e) {
@@ -303,21 +405,34 @@ static NSColor *colorFromARGB(uint32_t argb) {
 
             CGFloat frac = [self fractionForHz:f];
             if (frac < 0 || frac > 1) continue;
-            CGFloat x = std::round(frac * plotW) + 0.5;
-
-            CGContextBeginPath(ctx);
-            CGContextMoveToPoint(ctx, x, plotBottom);
-            CGContextAddLineToPoint(ctx, x, plotBottom + plotH);
-            CGContextStrokePath(ctx);
 
             NSString *label = (f >= 1000.0)
                 ? [NSString stringWithFormat:@"%gkHz", f / 1000.0]
                 : [NSString stringWithFormat:@"%dHz", (int)f];
             NSSize sz = [label sizeWithAttributes:attrs];
-            CGFloat lx = x - sz.width / 2;
-            if (lx > lastLabelRight + 4.0 && lx + sz.width < plotW) {
-                [label drawAtPoint:NSMakePoint(lx, (plotBottom - sz.height) / 2 + 1) withAttributes:attrs];
-                lastLabelRight = lx + sz.width;
+
+            if (_vertical) {
+                CGFloat y = std::round(_pOy + frac * _pFreq) + 0.5;
+                CGContextBeginPath(ctx);
+                CGContextMoveToPoint(ctx, _pOx, y);
+                CGContextAddLineToPoint(ctx, _pOx + _pMag, y);
+                CGContextStrokePath(ctx);
+                CGFloat ly = y - sz.height / 2;
+                if (ly > lastLabelEdge + 2.0 && ly + sz.height < _pOy + _pFreq) {
+                    [label drawAtPoint:NSMakePoint(_pOx + _pMag + 5, ly) withAttributes:attrs];
+                    lastLabelEdge = ly + sz.height;
+                }
+            } else {
+                CGFloat x = std::round(_pOx + frac * _pFreq) + 0.5;
+                CGContextBeginPath(ctx);
+                CGContextMoveToPoint(ctx, x, _pOy);
+                CGContextAddLineToPoint(ctx, x, _pOy + _pMag);
+                CGContextStrokePath(ctx);
+                CGFloat lx = x - sz.width / 2;
+                if (lx > lastLabelEdge + 4.0 && lx + sz.width < _pOx + _pFreq) {
+                    [label drawAtPoint:NSMakePoint(lx, (_pOy - sz.height) / 2 + 1) withAttributes:attrs];
+                    lastLabelEdge = lx + sz.width;
+                }
             }
         }
     }

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -1,0 +1,240 @@
+//
+//  SpectrumView.mm
+//  foo_jl_spectrum_mac
+//
+
+#import "SpectrumView.h"
+#include "../Core/SpectrumConfig.h"
+#include "../../../../shared/UIStyles.h"
+#include <vector>
+
+@implementation SpectrumView {
+    std::vector<float> _bars;
+    std::vector<float> _peaks;
+
+    // Cached settings (refreshed via reloadSettings)
+    int      _barStyle;
+    int      _gapPercent;
+    bool     _peakHold;
+    bool     _showDbGuides;
+    bool     _glass;
+    uint32_t _barColorLight;
+    uint32_t _bgColorLight;
+    uint32_t _barColorDark;
+    uint32_t _bgColorDark;
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+    self = [super initWithFrame:frameRect];
+    if (self) {
+        self.wantsLayer = YES;
+        [self reloadSettings];
+    }
+    return self;
+}
+
+- (BOOL)isFlipped { return NO; }  // origin bottom-left: bars grow upward
+
+- (void)reloadSettings {
+    using namespace spectrum_config;
+    _barStyle      = (int)getConfigInt(kKeyBarStyle, kDefaultBarStyle);
+    _gapPercent    = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
+    _peakHold      = getConfigBool(kKeyPeakHold, kDefaultPeakHold);
+    _showDbGuides  = getConfigBool(kKeyShowDbGuides, kDefaultShowDbGuides);
+    _glass         = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground);
+    _barColorLight = (uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight);
+    _bgColorLight  = (uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight);
+    _barColorDark  = (uint32_t)getConfigInt(kKeyBarColorDark, kDefaultBarColorDark);
+    _bgColorDark   = (uint32_t)getConfigInt(kKeyBgColorDark, kDefaultBgColorDark);
+    [self setNeedsDisplay:YES];
+}
+
+- (void)setBarsData:(const float *)bars peaks:(const float *)peaks count:(NSInteger)count {
+    if (count < 0) count = 0;
+    _bars.assign(bars, bars + count);
+    _peaks.assign(peaks, peaks + count);
+    [self setNeedsDisplay:YES];
+}
+
+#pragma mark - Color helpers
+
+static NSColor *colorFromARGB(uint32_t argb) {
+    return [NSColor colorWithSRGBRed:((argb >> 16) & 0xFF) / 255.0
+                               green:((argb >> 8) & 0xFF) / 255.0
+                                blue:(argb & 0xFF) / 255.0
+                               alpha:((argb >> 24) & 0xFF) / 255.0];
+}
+
+- (NSColor *)barColor {
+    return colorFromARGB(fb2k_ui::isDarkMode() ? _barColorDark : _barColorLight);
+}
+
+- (NSColor *)bgColor {
+    return colorFromARGB(fb2k_ui::isDarkMode() ? _bgColorDark : _bgColorLight);
+}
+
+#pragma mark - Drawing
+
+- (void)drawRect:(NSRect)dirtyRect {
+    [super drawRect:dirtyRect];
+
+    CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
+    const CGRect bounds = self.bounds;
+
+    // Background
+    if (!_glass) {
+        CGContextSetFillColorWithColor(ctx, [self bgColor].CGColor);
+        CGContextFillRect(ctx, bounds);
+    }
+
+    const NSInteger n = (NSInteger)_bars.size();
+    if (n <= 0) {
+        [self drawPlaceholder:bounds];
+        return;
+    }
+
+    const CGFloat W = bounds.size.width;
+    const CGFloat H = bounds.size.height;
+    const CGFloat maxBarH = H - 2.0;
+
+    // Reserve a right margin for the dB scale when it fits.
+    const CGFloat dbMargin = 34.0;
+    const BOOL drawGuides = _showDbGuides && (W > dbMargin + 40.0);
+    const CGFloat plotW = drawGuides ? (W - dbMargin) : W;
+
+    if (drawGuides) [self drawDbGuidesInRect:bounds plotWidth:plotW maxBarHeight:maxBarH context:ctx];
+
+    const CGFloat slot = plotW / (CGFloat)n;
+    CGFloat gap = slot * (_gapPercent / 100.0);
+    if (gap > slot - 1.0) gap = slot - 1.0;
+    if (gap < 0) gap = 0;
+    const CGFloat barW = slot - gap;
+
+    NSColor *base = [self barColor];
+
+    for (NSInteger i = 0; i < n; ++i) {
+        CGFloat v = _bars[i];
+        if (v < 0) v = 0; else if (v > 1) v = 1;
+        CGFloat h = v * maxBarH;
+        CGFloat x = (CGFloat)i * slot + gap * 0.5;
+
+        if (h >= 1.0) {
+            CGRect r = CGRectMake(x, 0, barW, h);
+            [self fillBar:r index:i count:n base:base value:v context:ctx];
+        }
+
+        // Peak cap
+        if (_peakHold) {
+            CGFloat pv = _peaks[i];
+            if (pv < 0) pv = 0; else if (pv > 1) pv = 1;
+            if (pv > 0.001) {
+                CGFloat py = pv * maxBarH;
+                CGRect cap = CGRectMake(x, py, barW, 2.0);
+                CGContextSetFillColorWithColor(ctx, [[base blendedColorWithFraction:0.4 ofColor:[NSColor whiteColor]] CGColor]);
+                CGContextFillRect(ctx, cap);
+            }
+        }
+    }
+}
+
+- (void)fillBar:(CGRect)r
+          index:(NSInteger)i
+          count:(NSInteger)n
+           base:(NSColor *)base
+          value:(CGFloat)v
+        context:(CGContextRef)ctx {
+    using namespace spectrum_config;
+
+    if (_barStyle == BarStyleSpectrum) {
+        // Hue mapped across frequency: low = red/orange, high = violet.
+        CGFloat hue = 0.75 * (CGFloat)i / (CGFloat)MAX(1, n - 1);  // 0..0.75
+        NSColor *c = [NSColor colorWithHue:(0.66 - hue) < 0 ? 0 : (0.66 - hue)
+                               saturation:0.85
+                               brightness:fb2k_ui::isDarkMode() ? 1.0 : 0.9
+                                    alpha:1.0];
+        CGContextSetFillColorWithColor(ctx, c.CGColor);
+        CGContextFillRect(ctx, r);
+        return;
+    }
+
+    if (_barStyle == BarStyleGradient) {
+        NSColor *bottom = [base blendedColorWithFraction:0.55 ofColor:[NSColor blackColor]];
+        NSColor *top = [base blendedColorWithFraction:0.25 ofColor:[NSColor whiteColor]];
+        NSGradient *grad = [[NSGradient alloc] initWithStartingColor:bottom endingColor:top];
+        NSBezierPath *path = [NSBezierPath bezierPathWithRect:r];
+        [grad drawInBezierPath:path angle:90.0];
+        return;
+    }
+
+    // Solid
+    CGContextSetFillColorWithColor(ctx, base.CGColor);
+    CGContextFillRect(ctx, r);
+}
+
+- (void)drawDbGuidesInRect:(CGRect)bounds
+                 plotWidth:(CGFloat)plotW
+              maxBarHeight:(CGFloat)maxBarH
+                   context:(CGContextRef)ctx {
+    const float floorDb = spectrum_config::kDisplayFloorDb;
+    const float ceilDb  = spectrum_config::kDisplayCeilDb;
+    const float range   = ceilDb - floorDb;
+    if (range <= 0) return;
+
+    const int step = 10;  // dB between marks
+    NSColor *lineColor = [[NSColor separatorColor] colorWithAlphaComponent:0.5];
+    NSDictionary *attrs = @{
+        NSFontAttributeName: [NSFont monospacedDigitSystemFontOfSize:9 weight:NSFontWeightRegular],
+        NSForegroundColorAttributeName: [NSColor tertiaryLabelColor]
+    };
+
+    CGContextSetLineWidth(ctx, 1.0);
+    CGContextSetStrokeColorWithColor(ctx, lineColor.CGColor);
+
+    // Marks at each multiple of `step` inside (floor, ceil].
+    int startDb = (int)(std::floor(ceilDb / step) * step);
+    for (int db = startDb; db > (int)floorDb; db -= step) {
+        CGFloat v = (db - floorDb) / range;
+        CGFloat y = std::round(v * maxBarH) + 0.5;  // crisp 1px line
+
+        CGContextBeginPath(ctx);
+        CGContextMoveToPoint(ctx, 0, y);
+        CGContextAddLineToPoint(ctx, plotW, y);
+        CGContextStrokePath(ctx);
+
+        NSString *label = [NSString stringWithFormat:@"%d", db];
+        NSSize sz = [label sizeWithAttributes:attrs];
+        [label drawAtPoint:NSMakePoint(plotW + 5, y - sz.height / 2) withAttributes:attrs];
+    }
+}
+
+- (void)drawPlaceholder:(CGRect)bounds {
+    NSString *msg = @"Spectrum Analyzer";
+    NSDictionary *attrs = @{
+        NSFontAttributeName: [NSFont systemFontOfSize:11],
+        NSForegroundColorAttributeName: [NSColor tertiaryLabelColor]
+    };
+    NSSize sz = [msg sizeWithAttributes:attrs];
+    NSPoint p = NSMakePoint((bounds.size.width - sz.width) / 2,
+                            (bounds.size.height - sz.height) / 2);
+    [msg drawAtPoint:p withAttributes:attrs];
+}
+
+#pragma mark - Appearance changes
+
+- (void)viewDidChangeEffectiveAppearance {
+    [super viewDidChangeEffectiveAppearance];
+    [self setNeedsDisplay:YES];
+}
+
+#pragma mark - Context menu
+
+- (void)rightMouseDown:(NSEvent *)event {
+    NSPoint pt = [self convertPoint:event.locationInWindow fromView:nil];
+    if ([self.delegate respondsToSelector:@selector(spectrumViewRequestsContextMenu:atPoint:)]) {
+        [self.delegate spectrumViewRequestsContextMenu:self atPoint:pt];
+    } else {
+        [super rightMouseDown:event];
+    }
+}
+
+@end

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -7,16 +7,23 @@
 #include "../Core/SpectrumConfig.h"
 #include "../../../../shared/UIStyles.h"
 #include <vector>
+#include <cmath>
 
 @implementation SpectrumView {
     std::vector<float> _bars;
+    std::vector<float> _shadow;
     std::vector<float> _peaks;
 
     // Cached settings (refreshed via reloadSettings)
     int      _barStyle;
     int      _gapPercent;
+    int      _minHz;
+    int      _maxHz;
+    bool     _logScale;
     bool     _peakHold;
+    bool     _shadowFill;
     bool     _showDbGuides;
+    bool     _showFreqAxis;
     bool     _glass;
     uint32_t _barColorLight;
     uint32_t _bgColorLight;
@@ -39,8 +46,13 @@
     using namespace spectrum_config;
     _barStyle      = (int)getConfigInt(kKeyBarStyle, kDefaultBarStyle);
     _gapPercent    = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
+    _minHz         = (int)getConfigInt(kKeyMinHz, kDefaultMinHz);
+    _maxHz         = (int)getConfigInt(kKeyMaxHz, kDefaultMaxHz);
+    _logScale      = getConfigInt(kKeyFreqScale, kDefaultFreqScale) == FreqScaleLog;
     _peakHold      = getConfigBool(kKeyPeakHold, kDefaultPeakHold);
+    _shadowFill    = getConfigBool(kKeyShadowFill, kDefaultShadowFill);
     _showDbGuides  = getConfigBool(kKeyShowDbGuides, kDefaultShowDbGuides);
+    _showFreqAxis  = getConfigBool(kKeyShowFreqAxis, kDefaultShowFreqAxis);
     _glass         = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground);
     _barColorLight = (uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight);
     _bgColorLight  = (uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight);
@@ -49,9 +61,13 @@
     [self setNeedsDisplay:YES];
 }
 
-- (void)setBarsData:(const float *)bars peaks:(const float *)peaks count:(NSInteger)count {
+- (void)setBarsData:(const float *)bars
+             shadow:(const float *)shadow
+              peaks:(const float *)peaks
+              count:(NSInteger)count {
     if (count < 0) count = 0;
     _bars.assign(bars, bars + count);
+    _shadow.assign(shadow, shadow + count);
     _peaks.assign(peaks, peaks + count);
     [self setNeedsDisplay:YES];
 }
@@ -73,6 +89,17 @@ static NSColor *colorFromARGB(uint32_t argb) {
     return colorFromARGB(fb2k_ui::isDarkMode() ? _bgColorDark : _bgColorLight);
 }
 
+// Fraction 0..1 across the plot width for a given frequency, matching the
+// analyzer's band mapping so gridlines line up with the bars.
+- (CGFloat)fractionForHz:(double)f {
+    if (_logScale) {
+        double lo = std::log10((double)_minHz);
+        double hi = std::log10((double)_maxHz);
+        return (CGFloat)((std::log10(f) - lo) / (hi - lo));
+    }
+    return (CGFloat)((f - _minHz) / (double)(_maxHz - _minHz));
+}
+
 #pragma mark - Drawing
 
 - (void)drawRect:(NSRect)dirtyRect {
@@ -80,6 +107,8 @@ static NSColor *colorFromARGB(uint32_t argb) {
 
     CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
     const CGRect bounds = self.bounds;
+    const CGFloat W = bounds.size.width;
+    const CGFloat H = bounds.size.height;
 
     // Background
     if (!_glass) {
@@ -93,16 +122,20 @@ static NSColor *colorFromARGB(uint32_t argb) {
         return;
     }
 
-    const CGFloat W = bounds.size.width;
-    const CGFloat H = bounds.size.height;
-    const CGFloat maxBarH = H - 2.0;
-
-    // Reserve a right margin for the dB scale when it fits.
+    // Reserve margins: right for the dB scale, bottom for frequency labels.
     const CGFloat dbMargin = 34.0;
-    const BOOL drawGuides = _showDbGuides && (W > dbMargin + 40.0);
-    const CGFloat plotW = drawGuides ? (W - dbMargin) : W;
+    const CGFloat freqMargin = 13.0;
+    const BOOL drawDb   = _showDbGuides && (W > dbMargin + 40.0);
+    const BOOL drawFreq = _showFreqAxis && (H > freqMargin + 30.0);
 
-    if (drawGuides) [self drawDbGuidesInRect:bounds plotWidth:plotW maxBarHeight:maxBarH context:ctx];
+    const CGFloat plotW = drawDb ? (W - dbMargin) : W;
+    const CGFloat plotBottom = drawFreq ? freqMargin : 0.0;
+    const CGFloat plotH = H - plotBottom - 2.0;
+    if (plotH <= 1.0) return;
+
+    // Grid behind the bars.
+    if (drawFreq) [self drawFreqAxisWithPlotWidth:plotW plotBottom:plotBottom plotHeight:plotH context:ctx];
+    if (drawDb)   [self drawDbGuidesWithPlotWidth:plotW plotBottom:plotBottom plotHeight:plotH context:ctx];
 
     const CGFloat slot = plotW / (CGFloat)n;
     CGFloat gap = slot * (_gapPercent / 100.0);
@@ -111,27 +144,37 @@ static NSColor *colorFromARGB(uint32_t argb) {
     const CGFloat barW = slot - gap;
 
     NSColor *base = [self barColor];
+    NSColor *shadowColor = [base blendedColorWithFraction:0.62 ofColor:[self bgColor]];
+    NSColor *capColor = [base blendedColorWithFraction:0.4 ofColor:[NSColor whiteColor]];
 
     for (NSInteger i = 0; i < n; ++i) {
-        CGFloat v = _bars[i];
-        if (v < 0) v = 0; else if (v > 1) v = 1;
-        CGFloat h = v * maxBarH;
         CGFloat x = (CGFloat)i * slot + gap * 0.5;
 
-        if (h >= 1.0) {
-            CGRect r = CGRectMake(x, 0, barW, h);
-            [self fillBar:r index:i count:n base:base value:v context:ctx];
+        CGFloat bv = _bars[i];  if (bv < 0) bv = 0; else if (bv > 1) bv = 1;
+        CGFloat barH = bv * plotH;
+
+        // Shadow fill (slow-decaying) behind the bright bar.
+        if (_shadowFill) {
+            CGFloat sv = _shadow[i]; if (sv < 0) sv = 0; else if (sv > 1) sv = 1;
+            CGFloat sh = sv * plotH;
+            if (sh > barH + 0.5) {
+                CGContextSetFillColorWithColor(ctx, shadowColor.CGColor);
+                CGContextFillRect(ctx, CGRectMake(x, plotBottom, barW, sh));
+            }
         }
 
-        // Peak cap
+        // Bright instantaneous bar.
+        if (barH >= 1.0) {
+            [self fillBar:CGRectMake(x, plotBottom, barW, barH) index:i count:n base:base context:ctx];
+        }
+
+        // Peak cap.
         if (_peakHold) {
-            CGFloat pv = _peaks[i];
-            if (pv < 0) pv = 0; else if (pv > 1) pv = 1;
+            CGFloat pv = _peaks[i]; if (pv < 0) pv = 0; else if (pv > 1) pv = 1;
             if (pv > 0.001) {
-                CGFloat py = pv * maxBarH;
-                CGRect cap = CGRectMake(x, py, barW, 2.0);
-                CGContextSetFillColorWithColor(ctx, [[base blendedColorWithFraction:0.4 ofColor:[NSColor whiteColor]] CGColor]);
-                CGContextFillRect(ctx, cap);
+                CGFloat py = plotBottom + pv * plotH;
+                CGContextSetFillColorWithColor(ctx, capColor.CGColor);
+                CGContextFillRect(ctx, CGRectMake(x, py, barW, 2.0));
             }
         }
     }
@@ -141,14 +184,14 @@ static NSColor *colorFromARGB(uint32_t argb) {
           index:(NSInteger)i
           count:(NSInteger)n
            base:(NSColor *)base
-          value:(CGFloat)v
         context:(CGContextRef)ctx {
     using namespace spectrum_config;
 
     if (_barStyle == BarStyleSpectrum) {
-        // Hue mapped across frequency: low = red/orange, high = violet.
-        CGFloat hue = 0.75 * (CGFloat)i / (CGFloat)MAX(1, n - 1);  // 0..0.75
-        NSColor *c = [NSColor colorWithHue:(0.66 - hue) < 0 ? 0 : (0.66 - hue)
+        // Hue mapped across frequency: low = blue, high = red.
+        CGFloat hue = 0.75 * (CGFloat)i / (CGFloat)MAX(1, n - 1);
+        CGFloat h = (0.66 - hue); if (h < 0) h = 0;
+        NSColor *c = [NSColor colorWithHue:h
                                saturation:0.85
                                brightness:fb2k_ui::isDarkMode() ? 1.0 : 0.9
                                     alpha:1.0];
@@ -161,8 +204,7 @@ static NSColor *colorFromARGB(uint32_t argb) {
         NSColor *bottom = [base blendedColorWithFraction:0.55 ofColor:[NSColor blackColor]];
         NSColor *top = [base blendedColorWithFraction:0.25 ofColor:[NSColor whiteColor]];
         NSGradient *grad = [[NSGradient alloc] initWithStartingColor:bottom endingColor:top];
-        NSBezierPath *path = [NSBezierPath bezierPathWithRect:r];
-        [grad drawInBezierPath:path angle:90.0];
+        [grad drawInBezierPath:[NSBezierPath bezierPathWithRect:r] angle:90.0];
         return;
     }
 
@@ -171,16 +213,18 @@ static NSColor *colorFromARGB(uint32_t argb) {
     CGContextFillRect(ctx, r);
 }
 
-- (void)drawDbGuidesInRect:(CGRect)bounds
-                 plotWidth:(CGFloat)plotW
-              maxBarHeight:(CGFloat)maxBarH
-                   context:(CGContextRef)ctx {
+#pragma mark - Grids
+
+- (void)drawDbGuidesWithPlotWidth:(CGFloat)plotW
+                       plotBottom:(CGFloat)plotBottom
+                       plotHeight:(CGFloat)plotH
+                          context:(CGContextRef)ctx {
     const float floorDb = spectrum_config::kDisplayFloorDb;
     const float ceilDb  = spectrum_config::kDisplayCeilDb;
     const float range   = ceilDb - floorDb;
     if (range <= 0) return;
 
-    const int step = 10;  // dB between marks
+    const int step = 10;
     NSColor *lineColor = [[NSColor separatorColor] colorWithAlphaComponent:0.5];
     NSDictionary *attrs = @{
         NSFontAttributeName: [NSFont monospacedDigitSystemFontOfSize:9 weight:NSFontWeightRegular],
@@ -190,20 +234,64 @@ static NSColor *colorFromARGB(uint32_t argb) {
     CGContextSetLineWidth(ctx, 1.0);
     CGContextSetStrokeColorWithColor(ctx, lineColor.CGColor);
 
-    // Marks at each multiple of `step` inside (floor, ceil].
     int startDb = (int)(std::floor(ceilDb / step) * step);
     for (int db = startDb; db > (int)floorDb; db -= step) {
         CGFloat v = (db - floorDb) / range;
-        CGFloat y = std::round(v * maxBarH) + 0.5;  // crisp 1px line
+        CGFloat y = std::round(plotBottom + v * plotH) + 0.5;
 
         CGContextBeginPath(ctx);
         CGContextMoveToPoint(ctx, 0, y);
         CGContextAddLineToPoint(ctx, plotW, y);
         CGContextStrokePath(ctx);
 
-        NSString *label = [NSString stringWithFormat:@"%d", db];
+        NSString *label = [NSString stringWithFormat:@"%ddB", db];
         NSSize sz = [label sizeWithAttributes:attrs];
         [label drawAtPoint:NSMakePoint(plotW + 5, y - sz.height / 2) withAttributes:attrs];
+    }
+}
+
+- (void)drawFreqAxisWithPlotWidth:(CGFloat)plotW
+                       plotBottom:(CGFloat)plotBottom
+                       plotHeight:(CGFloat)plotH
+                          context:(CGContextRef)ctx {
+    NSColor *lineColor = [[NSColor separatorColor] colorWithAlphaComponent:0.35];
+    NSDictionary *attrs = @{
+        NSFontAttributeName: [NSFont systemFontOfSize:8 weight:NSFontWeightRegular],
+        NSForegroundColorAttributeName: [NSColor tertiaryLabelColor]
+    };
+
+    CGContextSetLineWidth(ctx, 1.0);
+    CGContextSetStrokeColorWithColor(ctx, lineColor.CGColor);
+
+    CGFloat lastLabelRight = -1000.0;
+
+    // Ticks at 1..9 x 10^e (10,20,..,90,100,..,900,1k,..,20k).
+    for (int e = 1; e <= 5; ++e) {
+        int decade = (int)std::pow(10.0, e);
+        for (int m = 1; m <= 9; ++m) {
+            double f = (double)m * decade;
+            if (f < _minHz) continue;
+            if (f > _maxHz) break;
+
+            CGFloat frac = [self fractionForHz:f];
+            if (frac < 0 || frac > 1) continue;
+            CGFloat x = std::round(frac * plotW) + 0.5;
+
+            CGContextBeginPath(ctx);
+            CGContextMoveToPoint(ctx, x, plotBottom);
+            CGContextAddLineToPoint(ctx, x, plotBottom + plotH);
+            CGContextStrokePath(ctx);
+
+            NSString *label = (f >= 1000.0)
+                ? [NSString stringWithFormat:@"%gkHz", f / 1000.0]
+                : [NSString stringWithFormat:@"%dHz", (int)f];
+            NSSize sz = [label sizeWithAttributes:attrs];
+            CGFloat lx = x - sz.width / 2;
+            if (lx > lastLabelRight + 4.0 && lx + sz.width < plotW) {
+                [label drawAtPoint:NSMakePoint(lx, (plotBottom - sz.height) / 2 + 1) withAttributes:attrs];
+                lastLabelRight = lx + sz.width;
+            }
+        }
     }
 }
 

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -144,8 +144,12 @@ static NSColor *colorFromARGB(uint32_t argb) {
     const CGFloat barW = slot - gap;
 
     NSColor *base = [self barColor];
-    NSColor *shadowColor = [base blendedColorWithFraction:0.62 ofColor:[self bgColor]];
-    NSColor *capColor = [base blendedColorWithFraction:0.4 ofColor:[NSColor whiteColor]];
+    const BOOL dark = fb2k_ui::isDarkMode();
+    // Shadow band: a muted grey-blue so it reads distinctly above the bar.
+    NSColor *shadowColor = [base blendedColorWithFraction:0.6 ofColor:[NSColor grayColor]];
+    // Peak line: high-contrast against the background in either theme.
+    NSColor *capColor = dark ? [base blendedColorWithFraction:0.7 ofColor:[NSColor whiteColor]]
+                             : [base blendedColorWithFraction:0.5 ofColor:[NSColor blackColor]];
 
     for (NSInteger i = 0; i < n; ++i) {
         CGFloat x = (CGFloat)i * slot + gap * 0.5;

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -24,11 +24,14 @@
     bool     _shadowFill;
     bool     _showDbGuides;
     bool     _showFreqAxis;
+    int      _gridOpacity;
     bool     _glass;
     uint32_t _barColorLight;
     uint32_t _bgColorLight;
     uint32_t _barColorDark;
     uint32_t _bgColorDark;
+    uint32_t _gridColorLight;
+    uint32_t _gridColorDark;
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
@@ -53,11 +56,14 @@
     _shadowFill    = getConfigBool(kKeyShadowFill, kDefaultShadowFill);
     _showDbGuides  = getConfigBool(kKeyShowDbGuides, kDefaultShowDbGuides);
     _showFreqAxis  = getConfigBool(kKeyShowFreqAxis, kDefaultShowFreqAxis);
+    _gridOpacity   = (int)getConfigInt(kKeyGridOpacity, kDefaultGridOpacity);
     _glass         = getConfigBool(kKeyGlassBackground, kDefaultGlassBackground);
     _barColorLight = (uint32_t)getConfigInt(kKeyBarColorLight, kDefaultBarColorLight);
     _bgColorLight  = (uint32_t)getConfigInt(kKeyBgColorLight, kDefaultBgColorLight);
     _barColorDark  = (uint32_t)getConfigInt(kKeyBarColorDark, kDefaultBarColorDark);
     _bgColorDark   = (uint32_t)getConfigInt(kKeyBgColorDark, kDefaultBgColorDark);
+    _gridColorLight = (uint32_t)getConfigInt(kKeyGridColorLight, kDefaultGridColorLight);
+    _gridColorDark  = (uint32_t)getConfigInt(kKeyGridColorDark, kDefaultGridColorDark);
     [self setNeedsDisplay:YES];
 }
 
@@ -87,6 +93,24 @@ static NSColor *colorFromARGB(uint32_t argb) {
 
 - (NSColor *)bgColor {
     return colorFromARGB(fb2k_ui::isDarkMode() ? _bgColorDark : _bgColorLight);
+}
+
+- (NSColor *)gridColor {
+    return colorFromARGB(fb2k_ui::isDarkMode() ? _gridColorDark : _gridColorLight);
+}
+
+- (NSColor *)gridLineColor {
+    CGFloat a = _gridOpacity / 100.0;
+    if (a < 0) a = 0; else if (a > 1) a = 1;
+    return [[self gridColor] colorWithAlphaComponent:a];
+}
+
+- (NSColor *)gridLabelColor {
+    // Labels track opacity directly so 0% hides the grid entirely. A gentle
+    // boost keeps them a touch more legible than the lines at low settings.
+    CGFloat a = _gridOpacity / 100.0;
+    if (a > 0.0) a = MIN(1.0, a * 1.4);
+    return [[self gridColor] colorWithAlphaComponent:a];
 }
 
 // Fraction 0..1 across the plot width for a given frequency, matching the
@@ -229,10 +253,10 @@ static NSColor *colorFromARGB(uint32_t argb) {
     if (range <= 0) return;
 
     const int step = 10;
-    NSColor *lineColor = [[NSColor separatorColor] colorWithAlphaComponent:0.5];
+    NSColor *lineColor = [self gridLineColor];
     NSDictionary *attrs = @{
         NSFontAttributeName: [NSFont monospacedDigitSystemFontOfSize:9 weight:NSFontWeightRegular],
-        NSForegroundColorAttributeName: [NSColor tertiaryLabelColor]
+        NSForegroundColorAttributeName: [self gridLabelColor]
     };
 
     CGContextSetLineWidth(ctx, 1.0);
@@ -258,10 +282,10 @@ static NSColor *colorFromARGB(uint32_t argb) {
                        plotBottom:(CGFloat)plotBottom
                        plotHeight:(CGFloat)plotH
                           context:(CGContextRef)ctx {
-    NSColor *lineColor = [[NSColor separatorColor] colorWithAlphaComponent:0.35];
+    NSColor *lineColor = [self gridLineColor];
     NSDictionary *attrs = @{
         NSFontAttributeName: [NSFont systemFontOfSize:8 weight:NSFontWeightRegular],
-        NSForegroundColorAttributeName: [NSColor tertiaryLabelColor]
+        NSForegroundColorAttributeName: [self gridLabelColor]
     };
 
     CGContextSetLineWidth(ctx, 1.0);

--- a/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
+++ b/extensions/foo_jl_spectrum_mac/src/UI/SpectrumView.mm
@@ -61,6 +61,10 @@
     _gapPercent    = (int)getConfigInt(kKeyGapPercent, kDefaultGapPercent);
     _minHz         = (int)getConfigInt(kKeyMinHz, kDefaultMinHz);
     _maxHz         = (int)getConfigInt(kKeyMaxHz, kDefaultMaxHz);
+    // Same clamps as SpectrumAnalyzer::configure(), so fractionForHz: cannot
+    // divide by zero or take log10 of a non-positive bound.
+    if (_minHz < 10) _minHz = 10;
+    if (_maxHz <= _minHz + 100) _maxHz = _minHz + 100;
     _logScale      = getConfigInt(kKeyFreqScale, kDefaultFreqScale) == FreqScaleLog;
     _peakHold      = getConfigBool(kKeyPeakHold, kDefaultPeakHold);
     _shadowFill    = getConfigBool(kKeyShadowFill, kDefaultShadowFill);

--- a/extensions/foo_jl_spectrum_mac/src/fb2k_sdk.h
+++ b/extensions/foo_jl_spectrum_mac/src/fb2k_sdk.h
@@ -1,0 +1,17 @@
+//
+//  fb2k_sdk.h
+//  foo_jl_spectrum_mac
+//
+//  Common SDK header with macOS-specific configuration.
+//  Include THIS file instead of <foobar2000/SDK/foobar2000.h> directly.
+//
+
+#pragma once
+
+// Enable legacy cfg_var API for compatibility with Windows code
+// MUST be defined BEFORE including SDK headers
+#define FOOBAR2000_HAVE_CFG_VAR_LEGACY 1
+
+// Include foobar2000 SDK
+#include <foobar2000/SDK/foobar2000.h>
+#include <foobar2000/SDK/vis.h>

--- a/shared/sdk_config.rb
+++ b/shared/sdk_config.rb
@@ -84,7 +84,8 @@ module Fb2kVersions
     "cloud_streamer" => "CLOUD_STREAMER_VERSION",
     "cloud" => "CLOUD_STREAMER_VERSION",
     "tidal" => "TIDAL_VERSION",
-    "playback_controls" => "PLAYBACK_CONTROLS_VERSION"
+    "playback_controls" => "PLAYBACK_CONTROLS_VERSION",
+    "spectrum" => "SPECTRUM_VERSION"
   }
 
   # Parse version.h and extract versions

--- a/shared/version.h
+++ b/shared/version.h
@@ -48,3 +48,7 @@
 // Tidal Integration
 #define TIDAL_VERSION "0.3.1"
 #define TIDAL_VERSION_INT 031
+
+// Spectrum Analyzer
+#define SPECTRUM_VERSION "0.1.0"
+#define SPECTRUM_VERSION_INT 010


### PR DESCRIPTION
## Summary

Adds `foo_jl_spectrum_mac`, a from-scratch real-time spectrum analyzer
component for foobar2000 on macOS. It pulls normalized FFT data from the
core `visualisation_manager` (no third-party DSP) and renders with Core
Graphics as an embeddable UI element.

## Features

- **Analyzer core** (pure C++): log/linear frequency band mapping rebuilt on
  sample-rate change, per-bar attack/decay smoothing, three independent fall
  timescales (bar, shadow envelope, peak line with hold), 0..-80 dB display
  window shared between bars and grid.
- **Rendering**: solid / gradient / spectrum bar styles, discrete bars or
  continuous filled curve, horizontal or vertical orientation, falling peak
  caps, dim shadow fill, dB scale and logarithmic frequency axis with
  de-cluttered labels, optional glass background.
- **Preferences**: programmatic prefs page covering bar count (up to 256),
  FFT size, frequency scale/range, smoothing, dynamics (shadow/peak fall
  rates, peak hold), grid color and opacity, per-appearance light/dark
  colors, and 10 color theme presets (Nord, Dracula, Gruvbox, Solarized,
  Tokyo Night, Catppuccin, Monokai, ...). Live views reload via notification.
  Settings persist through `configStore` (cfg_var does not persist on
  macOS v2).
- **Lifecycle**: visualisation streams are released via `initquit` before
  service teardown, fixing an abort on quit; timers are guarded against
  restart during shutdown.

----------------------------------------
Screenshots:
- 1st pic shows usage of curve draw mode
- 2nd pic shows bar draw mode
- 3rd pic shows curve draw mode again, but with vertical orientation set
- 4th pic shows the component's preferences

<img width="2204" height="1324" alt="Screenshot 2026-08-22 at 4 28 42" src="https://github.com/user-attachments/assets/e094168c-6e54-45ae-989a-9fd284110206" />
<img width="2204" height="1324" alt="Screenshot 2026-08-22 at 4 30 30" src="https://github.com/user-attachments/assets/4b0b0a83-a22b-4715-a0ec-8a2be26d32d1" />
<img width="2247" height="1237" alt="Screenshot 2026-08-22 at 4 57 54" src="https://github.com/user-attachments/assets/6fcb87b4-9f2f-4671-ab5e-98c120d4314d" />
<img width="1383" height="1032" alt="Screenshot 2026-08-22 at 8 08 51" src="https://github.com/user-attachments/assets/8146ac7c-3d42-4dbc-9e1e-17de4fed17c9" />

